### PR TITLE
ocp4.18

### DIFF
--- a/group_vars/all
+++ b/group_vars/all
@@ -1,7 +1,7 @@
 ---
 # Default version to be used, run "make ocp-versions" to see which are the latest
 # ones and download them with "make ocp-clients"
-ocp_version: "4.17.17"
+ocp_version: "4.18.9"
 
 ocp_domain: "aws.validatedpatterns.io"
 ocp_cluster_name: "gpfs-test"

--- a/playbooks/print-ocp-versions.yml
+++ b/playbooks/print-ocp-versions.yml
@@ -6,7 +6,6 @@
     ocp_url: https://mirror.openshift.com/pub/openshift-v4/x86_64/clients/ocp/
     ocp_tmp_file: /tmp/ocp-versions.html
     major_versions:
-      - "4.16"
       - "4.17"
       - "4.18"
   tasks:


### PR DESCRIPTION
- **Switch to 4.18 by default**
- **Drop 4.16 from ocp-versions**

## Summary by Sourcery

Update OpenShift Container Platform (OCP) versions to use 4.18 as the default and remove 4.16 support

New Features:
- Set OCP 4.18 as the primary version in the version list

Chores:
- Remove OCP 4.16 from the supported versions list