### PR TITLE
Some more power90 testing

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -28,6 +28,7 @@ ocp-clients: ## Reads ocp_versions list and makes sure client tools are download
 .PHONY: install
 install: ## Install an OCP cluster on AWS using the openshift-fusion-access operator and configures gpfs on top
 	ansible-playbook -i hosts $(TAGS_STRING) $(EXTRA_ARGS) $(EXTRA_VARS) playbooks/install.yml
+	-@notify.sh "AWS install finished"
 
 .PHONY: virt
 virt: ## Configures the virt bits (only for POWER90)
@@ -45,6 +46,7 @@ gpfs-health: ## Prints some GPFS healthcheck commands
 .PHONY: destroy
 destroy: ## Destroy installed AWS cluster
 	ansible-playbook -i hosts $(TAGS_STRING) $(EXTRA_ARGS) $(EXTRA_VARS) playbooks/destroy.yml
+	-@notify.sh "AWS destroy finished"
 
 .PHONY: list-tags
 list-tags: ## Lists all tags in the install playbook

--- a/playbooks/install.yml
+++ b/playbooks/install.yml
@@ -179,7 +179,6 @@
         - 2_aws
       ansible.builtin.shell: |
         aws ec2 --profile {{ aws_profile }} --region {{ ocp_region }} authorize-security-group-ingress --group-id {{ sg_worker_id }} --protocol tcp --port 12345 --source-group {{ sg_worker_id }}
-        aws ec2 --profile {{ aws_profile }} --region {{ ocp_region }} authorize-security-group-ingress --group-id {{ sg_worker_id }} --protocol tcp --port 47443 --source-group {{ sg_worker_id }}
         aws ec2 --profile {{ aws_profile }} --region {{ ocp_region }} authorize-security-group-ingress --group-id {{ sg_worker_id }} --protocol tcp --port 1191 --source-group {{ sg_worker_id }}
         aws ec2 --profile {{ aws_profile }} --region {{ ocp_region }} authorize-security-group-ingress --group-id {{ sg_worker_id }} --protocol tcp --port 60000-61000 --source-group {{ sg_worker_id }}
 

--- a/playbooks/install.yml
+++ b/playbooks/install.yml
@@ -179,6 +179,7 @@
         - 2_aws
       ansible.builtin.shell: |
         aws ec2 --profile {{ aws_profile }} --region {{ ocp_region }} authorize-security-group-ingress --group-id {{ sg_worker_id }} --protocol tcp --port 12345 --source-group {{ sg_worker_id }}
+        aws ec2 --profile {{ aws_profile }} --region {{ ocp_region }} authorize-security-group-ingress --group-id {{ sg_worker_id }} --protocol tcp --port 47443 --source-group {{ sg_worker_id }}
         aws ec2 --profile {{ aws_profile }} --region {{ ocp_region }} authorize-security-group-ingress --group-id {{ sg_worker_id }} --protocol tcp --port 1191 --source-group {{ sg_worker_id }}
         aws ec2 --profile {{ aws_profile }} --region {{ ocp_region }} authorize-security-group-ingress --group-id {{ sg_worker_id }} --protocol tcp --port 60000-61000 --source-group {{ sg_worker_id }}
 

--- a/playbooks/install.yml
+++ b/playbooks/install.yml
@@ -145,7 +145,7 @@
         if [ $({{ oc_bin }} get mcp/worker -o jsonpath='{.status.readyMachineCount}') != $({{ oc_bin }} get mcp/worker -o jsonpath='{.status.machineCount}') ]; then
           exit 1
         fi
-      retries: 30
+      retries: 40
       delay: 90
       register: mcp_ready
       until: mcp_ready is not failed

--- a/playbooks/operator-install.yml
+++ b/playbooks/operator-install.yml
@@ -69,3 +69,23 @@
   delay: 20
   register: fusionaccess_ready
   until: fusionaccess_ready is not failed
+
+# FIXME(bandini): This networkpolicy seems to be needed on AWS. Still haven't fully root caused it
+- name: Template csi network policy
+  ansible.builtin.template:
+    src: ../templates/networkpolicy-csi.yaml
+    dest: "{{ gpfsfolder }}/networkpolicy-csi.yaml"
+  tags:
+    - 5_operator
+
+- name: Apply csi network policy
+  tags:
+    - 5_operator
+  ansible.builtin.shell: |
+    set -e
+    export KUBECONFIG={{ kubeconfig }}
+    {{ oc_bin }} apply -f "{{ gpfsfolder }}/networkpolicy-csi.yaml"
+  retries: 5
+  delay: 20
+  register: fusionaccess_ready
+  until: fusionaccess_ready is not failed

--- a/playbooks/operator-install.yml
+++ b/playbooks/operator-install.yml
@@ -47,6 +47,7 @@
   ansible.builtin.shell: |
     set -e
     export KUBECONFIG={{ kubeconfig }}
+    {{ oc_bin }} delete secret -n openshift-fusion-access fusion-pullsecret || /bin/true
     {{ oc_bin }} create secret -n openshift-fusion-access generic fusion-pullsecret  \
       --from-file=.dockerconfigjson={{ ibmpullsecretfile }} \
       --type=kubernetes.io/dockerconfigjson
@@ -65,8 +66,8 @@
     set -e
     export KUBECONFIG={{ kubeconfig }}
     {{ oc_bin }} apply -f "{{ gpfsfolder }}/fusionaccess.yaml"
-  retries: 10
-  delay: 20
+  retries: 15
+  delay: 30
   register: fusionaccess_ready
   until: fusionaccess_ready is not failed
 

--- a/playbooks/operator-install.yml
+++ b/playbooks/operator-install.yml
@@ -85,7 +85,7 @@
   ansible.builtin.shell: |
     set -e
     export KUBECONFIG={{ kubeconfig }}
-    {{ oc_bin }} apply -f "{{ gpfsfolder }}/networkpolicy-csi.yaml"
+    # {{ oc_bin }} apply -f "{{ gpfsfolder }}/networkpolicy-csi.yaml"
   retries: 5
   delay: 20
   register: fusionaccess_ready

--- a/templates/networkpolicy-csi.yaml
+++ b/templates/networkpolicy-csi.yaml
@@ -1,0 +1,32 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: bando-allow-to-scale-bandini
+  namespace: ibm-spectrum-scale-csi
+spec:
+  podSelector: {}  # Applies to all pods in this namespace
+  egress:
+  policyTypes:
+  - Egress
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: bando-allow-from-csi
+  namespace: ibm-spectrum-scale
+spec:
+  podSelector: {}  # Applies to all pods in this namespace
+  ingress:
+  - from:
+    ports:
+    - port: 443
+      protocol: TCP
+    - port: 47443
+      protocol: TCP
+    - port: 8080
+      protocol: TCP
+    # - namespaceSelector:
+    #     matchLabels:
+    #       name: ibm-spectrum-scale-csi
+  policyTypes:
+  - Ingress


### PR DESCRIPTION
- **Trying to add 47443 into the sg**
- **Add workaround for CSI talking to GUI pods issue**
- **Add some notification script**
- **Increase MCP waiting time**
- **Increase fusionaccess retries and delete pull secret if it exists**
- **Drop the 47443 port, makes no sense that this would be needed**
- **Do not apply the new network policy just yet**

## Summary by Sourcery

Modify installation and configuration scripts for OpenShift cluster with various improvements and workarounds for Fusion Access and CSI deployment

New Features:
- Create a network policy template for CSI and Scale namespaces (currently commented out)

Bug Fixes:
- Delete existing pull secret before creating a new one to prevent potential conflicts

Enhancements:
- Increase retry and waiting times for MCP and Fusion Access deployment
- Add flexibility to pull secret management

Chores:
- Add notification scripts for install and destroy operations