### PR TITLE
Fix true call which might not exist on macosx

### DIFF
--- a/playbooks/operator-install.yml
+++ b/playbooks/operator-install.yml
@@ -47,7 +47,7 @@
   ansible.builtin.shell: |
     set -e
     export KUBECONFIG={{ kubeconfig }}
-    {{ oc_bin }} delete secret -n openshift-fusion-access fusion-pullsecret || /bin/true
+    {{ oc_bin }} delete secret -n openshift-fusion-access fusion-pullsecret || true
     {{ oc_bin }} create secret -n openshift-fusion-access generic fusion-pullsecret  \
       --from-file=.dockerconfigjson={{ ibmpullsecretfile }} \
       --type=kubernetes.io/dockerconfigjson


### PR DESCRIPTION
## Summary by Sourcery

Bug Fixes:
- Replace '/bin/true' with 'true' to ensure compatibility across different Unix-like systems, particularly macOS