### PR TITLE
Drop network policy because it is not working on AWS at least

### DIFF
--- a/templates/cluster.yaml
+++ b/templates/cluster.yaml
@@ -34,5 +34,5 @@ spec:
   license:
     accept: true
     license: data-management
-  networkPolicy: {}
-
+  # This is problematic on AWS
+  # networkPolicy: {}


### PR DESCRIPTION
## Summary by Sourcery

Chores:
- Commented out network policy configuration in the cluster template to address deployment problems on AWS infrastructure