### PR TITLE
Network changes

### DIFF
--- a/playbooks/operator-install.yml
+++ b/playbooks/operator-install.yml
@@ -78,15 +78,15 @@
     dest: "{{ gpfsfolder }}/networkpolicy-csi.yaml"
   tags:
     - 5_operator
-
-- name: Apply csi network policy
-  tags:
-    - 5_operator
-  ansible.builtin.shell: |
-    set -e
-    export KUBECONFIG={{ kubeconfig }}
-    # {{ oc_bin }} apply -f "{{ gpfsfolder }}/networkpolicy-csi.yaml"
-  retries: 5
-  delay: 20
-  register: fusionaccess_ready
-  until: fusionaccess_ready is not failed
+#
+# - name: Apply csi network policy
+#   tags:
+#     - 5_operator
+#   ansible.builtin.shell: |
+#     set -e
+#     export KUBECONFIG={{ kubeconfig }}
+#     # {{ oc_bin }} apply -f "{{ gpfsfolder }}/networkpolicy-csi.yaml"
+#   retries: 5
+#   delay: 20
+#   register: fusionaccess_ready
+#   until: fusionaccess_ready is not failed


### PR DESCRIPTION
- **Drop network policy because it is not working on AWS at least**
- **Do not apply network policy, we removed it from cluster object**

## Summary by Sourcery

Chores:
- Commented out network policy application step in the operator installation playbook