### PR TITLE
Drop namespace from spectrum cluster object

### DIFF
--- a/templates/cluster.yaml
+++ b/templates/cluster.yaml
@@ -2,7 +2,6 @@ apiVersion: scale.spectrum.ibm.com/v1beta1
 kind: Cluster
 metadata:
   name: ibm-spectrum-scale
-  namespace: ibm-spectrum-scale
 spec:
   pmcollector:
     nodeSelector:


### PR DESCRIPTION
It is not namespaced anyways
