### PR TITLE
Add second disk for power90

### DIFF
--- a/group_vars/all
+++ b/group_vars/all
@@ -24,6 +24,7 @@ ebs_volume_type_two: "io2"
 ebs_device_name_two: "/dev/sdd"
 ebs_iops_two: 5000
 gpfs_volume_name_two: "gpfs-volume-fast"
+gpfs_fs_name_two: "localfilesystem2"
 
 # Only used when installing without the operator
 gpfs_version: "v5.2.2.x"

--- a/group_vars/all
+++ b/group_vars/all
@@ -18,6 +18,12 @@ ebs_volume_size: 150
 ebs_volume_type: "io2"
 ebs_device_name: "/dev/sdd"
 ebs_iops: 5000
+# These are unused unless doing the power90
+ebs_volume_size_two: 150
+ebs_volume_type_two: "io2"
+ebs_device_name_two: "/dev/sdd"
+ebs_iops_two: 5000
+gpfs_volume_name_two: "gpfs-volume-fast"
 
 # Only used when installing without the operator
 gpfs_version: "v5.2.2.x"
@@ -49,3 +55,4 @@ pullsecret: "{{ lookup('file', '~/.pullsecret.json' | expanduser) }}"
 ibmpullsecretfile: "{{ '~/.openshift-storage-pull-authfile.json' | expanduser }}"
 kubeadmin_pass: "{{ lookup('file', '~/.kubeadminpass',errors='ignore' | expanduser) }}"
 ssh_pubkey: "{{ lookup('file', '~/.ssh/id_rsa.pub' | expanduser) }}"
+power_ninety: false

--- a/playbooks/destroy.yml
+++ b/playbooks/destroy.yml
@@ -41,3 +41,25 @@
         state: absent
       loop: "{{ volume_info.volumes }}"
       when: volume_info.volumes | length > 0
+
+    - name: Get the Volume ID by Tag Name (2)
+      amazon.aws.ec2_vol_info:
+        profile: "{{ aws_profile }}"
+        region: "{{ ocp_region }}"
+        filters:
+          "tag:Name": "{{ gpfs_volume_name_two }}"
+      register: volume_info_two
+      when: power_ninety | bool
+
+    - name: Debug volume (2)
+      ansible.builtin.debug:
+        msg: "{{ volume_info }}"
+
+    - name: Delete EBS io2 volume (2)
+      amazon.aws.ec2_vol:
+        profile: "{{ aws_profile }}"
+        region: "{{ ocp_region }}"
+        id: "{{ item.id }}"
+        state: absent
+      loop: "{{ volume_info_two.volumes }}"
+      when: volume_info_two.volumes | length > 0

--- a/playbooks/gpfs-setup.yml
+++ b/playbooks/gpfs-setup.yml
@@ -135,6 +135,8 @@
   until: filesystem_ready is not failed
 
 - name: Wait for the filesystem to be ready
+  tags:
+    - 7_gpfs
   ansible.builtin.shell: |
     set -ex
     export KUBECONFIG={{ kubeconfig }}
@@ -256,6 +258,8 @@
     until: filesystem_ready is not failed
 
   - name: Wait for the filesystem to be ready (2)
+    tags:
+      - 7_gpfs
     ansible.builtin.shell: |
       set -ex
       export KUBECONFIG={{ kubeconfig }}

--- a/playbooks/gpfs-setup.yml
+++ b/playbooks/gpfs-setup.yml
@@ -115,6 +115,8 @@
   register: localdisk_ready
   until: localdisk_ready is not failed
 
+
+
 - name: Template the filesystem
   tags:
     - 7_gpfs
@@ -179,3 +181,101 @@
     set -ex
     export KUBECONFIG={{ kubeconfig }}
     {{ oc_bin }} apply -f "{{ gpfsfolder }}/test_consume.yaml"
+
+- block:
+  - name: Get the Volume ID by Tag Name again (2)
+    tags:
+      - 6_gpfs
+    amazon.aws.ec2_vol_info:
+      profile: "{{ aws_profile }}"
+      region: "{{ ocp_region }}"
+      filters:
+        "tag:Name": "{{ gpfs_volume_name_two }}"
+    register: volume_info_two
+
+  - name: Fail if there is not exactly one ebs volume (2)
+    tags:
+      - 6_gpfs
+    ansible.builtin.fail:
+      msg: "There must be only one ebs volumes called {{ gpfs_volume_name }}: {{ volume_info }}"
+    when: volume_info_two.volumes | length != 1
+
+  - name: Set volumeid fact
+    tags:
+      - 6_gpfs
+    ansible.builtin.set_fact:
+      ebs_volid_two: "{{ volume_info_two.volumes[0].id | replace('-', '') }}"
+
+  - name: Debug volumeid fact
+    tags:
+      - 6_gpfs
+    ansible.builtin.debug:
+      msg: "{{ ebs_volid_two }}"
+
+  # This actually works for any worker when using the symlink
+  - name: Set device name for worker_0 (2)
+    tags:
+      - 6_gpfs
+    ansible.builtin.set_fact:
+      realdevice_two: "/dev/disk/by-id/nvme-Amazon_Elastic_Block_Store_{{ ebs_volid_two }}"
+
+  - name: Template the localdisk (2)
+    tags:
+      - 6_gpfs
+    ansible.builtin.template:
+      src: ../templates/localdisk.yaml
+      dest: "{{ gpfsfolder }}/localdisk2.yaml"
+
+  - name: Apply the localdisk (2)
+    tags:
+      - 6_gpfs
+    ansible.builtin.shell: |
+      set -ex
+      export KUBECONFIG={{ kubeconfig }}
+      {{ oc_bin }} apply -f "{{ gpfsfolder }}/localdisk2.yaml"
+    retries: 10
+    delay: 30
+    register: localdisk_ready
+    until: localdisk_ready is not failed
+
+  - name: Apply the filesystem (2)
+    tags:
+      - 7_gpfs
+    ansible.builtin.shell: |
+      set -ex
+      export KUBECONFIG={{ kubeconfig }}
+      {{ oc_bin }} apply -f "{{ gpfsfolder }}/filesystem2.yaml"
+    retries: 10
+    delay: 30
+    register: filesystem_ready
+    until: filesystem_ready is not failed
+
+  - name: Wait for the filesystem to be ready (2)
+    ansible.builtin.shell: |
+      set -ex
+      export KUBECONFIG={{ kubeconfig }}
+      {{ oc_bin }} get filesystem -n ibm-spectrum-scale {{ gpfs_fs_name_two }} -o jsonpath='{.status.pools[0].totalDiskSize}' | grep "{{ ebs_volume_size_two }}"
+    retries: 15
+    delay: 30
+    register: filesystem_ready
+    until: filesystem_ready is not failed
+
+  - name: Template the snapshotclass and storageclass
+    tags:
+      - 7_gpfs
+    ansible.builtin.template:
+      src: ../templates/{{ item }}
+      dest: "{{ gpfsfolder }}/{{ item }}"
+    loop:
+      - storageclass2.yaml
+
+  - name: Apply the snapshotclass and storageclass
+    tags:
+      - 7_gpfs
+    ansible.builtin.shell: |
+      set -ex
+      export KUBECONFIG={{ kubeconfig }}
+      {{ oc_bin }} apply -f "{{ gpfsfolder }}/{{ item }}"
+    loop:
+      - storageclass2.yaml
+  when: power_ninety | bool

--- a/playbooks/gpfs-setup.yml
+++ b/playbooks/gpfs-setup.yml
@@ -115,8 +115,6 @@
   register: localdisk_ready
   until: localdisk_ready is not failed
 
-
-
 - name: Template the filesystem
   tags:
     - 7_gpfs
@@ -223,7 +221,7 @@
     tags:
       - 6_gpfs
     ansible.builtin.template:
-      src: ../templates/localdisk.yaml
+      src: ../templates/localdisk2.yaml
       dest: "{{ gpfsfolder }}/localdisk2.yaml"
 
   - name: Apply the localdisk (2)
@@ -237,6 +235,13 @@
     delay: 30
     register: localdisk_ready
     until: localdisk_ready is not failed
+
+  - name: Template the filesystem
+    tags:
+      - 7_gpfs
+    ansible.builtin.template:
+      src: ../templates/filesystem2.yaml
+      dest: "{{ gpfsfolder }}/filesystem2.yaml"
 
   - name: Apply the filesystem (2)
     tags:

--- a/playbooks/install.yml
+++ b/playbooks/install.yml
@@ -208,7 +208,7 @@
         availability_zone: "{{ ocp_az }}"
         volume_size: "{{ ebs_volume_size }}"
         volume_type: "{{ ebs_volume_type }}"
-        multi_attach: yes
+        multi_attach: true
         iops: "{{ ebs_iops }}"
         tags:
           Name: "{{ gpfs_volume_name }}"
@@ -233,7 +233,7 @@
         availability_zone: "{{ ocp_az }}"
         volume_size: "{{ ebs_volume_size_two }}"
         volume_type: "{{ ebs_volume_type_two }}"
-        multi_attach: yes
+        multi_attach: true
         iops: "{{ ebs_iops_two }}"
         tags:
           Name: "{{ gpfs_volume_name_two }}"

--- a/playbooks/install.yml
+++ b/playbooks/install.yml
@@ -225,6 +225,32 @@
       loop: "{{ worker_ec2_ids }}"
       when: ebs_volume.volume_id is defined
 
+    - name: Create EBS io2 volume (2)
+      tags:
+        - 3_ebs
+      amazon.aws.ec2_vol:
+        region: "{{ ocp_region }}"
+        availability_zone: "{{ ocp_az }}"
+        volume_size: "{{ ebs_volume_size_two }}"
+        volume_type: "{{ ebs_volume_type_two }}"
+        multi_attach: yes
+        iops: "{{ ebs_iops_two }}"
+        tags:
+          Name: "{{ gpfs_volume_name_two }}"
+      register: ebs_volume_two
+      when: power_ninety | bool
+
+    - name: Attach EBS volume to workers (2)
+      tags:
+        - 3_ebs
+      amazon.aws.ec2_vol:
+        region: "{{ ocp_region }}"
+        instance: "{{ item }}"
+        id: "{{ ebs_volume_two.volume_id }}"
+        device_name: "{{ ebs_device_name_two }}"
+      loop: "{{ worker_ec2_ids }}"
+      when: ebs_volume_two.volume_id is defined and power_ninety | bool
+
     # Installs GPFS with the openshift-storage-scale operator
     - name: Install gpfs bits
       ansible.builtin.import_tasks: operator-install.yml

--- a/playbooks/operator-install.yml
+++ b/playbooks/operator-install.yml
@@ -1,6 +1,6 @@
 - name: Create gpfs folder
   tags:
-    - 4_gpfs
+    - 4_operator
   ansible.builtin.file:
     path: "{{ gpfsfolder }}"
     state: directory

--- a/templates/filesystem2.yaml
+++ b/templates/filesystem2.yaml
@@ -1,0 +1,21 @@
+apiVersion: scale.spectrum.ibm.com/v1beta1
+kind: Filesystem
+metadata:
+  name: {{ gpfs_fs_name_two }}
+  namespace: ibm-spectrum-scale
+spec:
+  local:
+    blockSize: 4M
+    pools:
+    - name: system
+      disks:
+      - shareddisk2
+    # only 1-way is supported for LFS https://www.ibm.com/docs/en/scalecontainernative/5.2.1?topic=systems-local-file-system#filesystem-spec
+    replication: 1-way
+    type: shared
+  seLinuxOptions:
+    level: s0
+    role: object_r
+    type: container_file_t
+    user: system_u
+

--- a/templates/localdisk2.yaml
+++ b/templates/localdisk2.yaml
@@ -1,0 +1,19 @@
+apiVersion: scale.spectrum.ibm.com/v1beta1
+kind: LocalDisk
+metadata:
+  name: shareddisk2
+  namespace: ibm-spectrum-scale
+spec:
+  # FIXME(bandini): the stable symlink gets EPERM from gpfs, so for now this will do
+  # note that a node reboot might just rename this devices, so...
+  # device: "/dev/disk/by-id/nvme-Amazon_Elastic_Block_Store_{{ ebs_volid }}"
+  device: {{ realdevice_two }}
+  node: {{ worker_nodes[0] }}
+  # nodeConnectionSelector defines the nodes that have the shared lun directly attached to them
+  nodeConnectionSelector:
+    matchExpressions:
+    - key: node-role.kubernetes.io/worker
+      operator: Exists
+
+  # set below only during testing
+  existingDataSkipVerify: true

--- a/templates/storageclass2.yaml
+++ b/templates/storageclass2.yaml
@@ -1,0 +1,10 @@
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+  name: ibm-test-sc2
+parameters:
+  volBackendFs: {{ gpfs_fs_name_two }}
+provisioner: spectrumscale.csi.ibm.com
+reclaimPolicy: Delete
+volumeBindingMode: Immediate
+allowVolumeExpansion: true

--- a/vars/power90.yaml
+++ b/vars/power90.yaml
@@ -6,3 +6,8 @@ ocp_master_type: m5.4xlarge
 ocp_az: eu-north-1a
 ocp_region: eu-north-1
 aws_profile: default
+
+gpfs_volume_name_two: "gpfs-volume-fast"
+ebs_volume_size_two: 310
+ebs_device_name_two: "/dev/sde"
+ebs_iops_two: 10000


### PR DESCRIPTION
## Summary by Sourcery

Add a second EBS volume for Power90 cluster configuration

New Features:
- Configure a second EBS volume with specific parameters for Power90 infrastructure

Enhancements:
- Extend storage configuration to support an additional high-performance EBS volume

Deployment:
- Add configuration for a second EBS volume with io2 type, multi-attach support, and specific IOPS settings