### PR TITLE
virt work

### DIFF
--- a/group_vars/all
+++ b/group_vars/all
@@ -59,3 +59,4 @@ ssh_pubkey: "{{ lookup('file', '~/.ssh/id_rsa.pub' | expanduser) }}"
 power_ninety: false
 vmpass: "{{ lookup('file', '~/.vmpass' | expanduser) }}"
 dbperf_tar: "https://acksyn.org/stuff/hammerdb-tpcc-wrapper-scripts-kit.tar"
+virt_test_ns: "virt-test"

--- a/group_vars/all
+++ b/group_vars/all
@@ -57,3 +57,5 @@ ibmpullsecretfile: "{{ '~/.openshift-storage-pull-authfile.json' | expanduser }}
 kubeadmin_pass: "{{ lookup('file', '~/.kubeadminpass',errors='ignore' | expanduser) }}"
 ssh_pubkey: "{{ lookup('file', '~/.ssh/id_rsa.pub' | expanduser) }}"
 power_ninety: false
+vmpass: "{{ lookup('file', '~/.vmpass' | expanduser) }}"
+dbperf_tar: "https://acksyn.org/stuff/hammerdb-tpcc-wrapper-scripts-kit.tar"

--- a/playbooks/virt.yml
+++ b/playbooks/virt.yml
@@ -52,3 +52,15 @@
       until: virt_apply is not failed
       retries: 10
       delay: 30
+
+    - name: Template virt db bits
+      tags:
+      - fuck1
+      ansible.builtin.template:
+        src: ../templates/{{ item }}
+        dest: "{{ gpfsfolder }}/{{ item }}"
+      loop:
+        - virt-ssh-secret.yaml
+        - virt-vm-db-service.yaml
+        - virt-vm-db.yaml
+        - virt-vm-cloudinit.yaml

--- a/playbooks/virt.yml
+++ b/playbooks/virt.yml
@@ -54,10 +54,13 @@
       delay: 30
 
     - name: Template virt db bits
+      tags:
+        - virt1
       ansible.builtin.template:
         src: ../templates/{{ item }}
         dest: "{{ gpfsfolder }}/{{ item }}"
       loop:
+        - virt-ns.yaml
         - virt-ssh-secret.yaml
         - virt-vm-db-service.yaml
         - virt-vm-db.yaml

--- a/playbooks/virt.yml
+++ b/playbooks/virt.yml
@@ -54,8 +54,6 @@
       delay: 30
 
     - name: Template virt db bits
-      tags:
-      - fuck1
       ansible.builtin.template:
         src: ../templates/{{ item }}
         dest: "{{ gpfsfolder }}/{{ item }}"

--- a/templates/storageclass.yaml
+++ b/templates/storageclass.yaml
@@ -2,8 +2,8 @@ apiVersion: storage.k8s.io/v1
 kind: StorageClass
 metadata:
   name: ibm-test-sc
-  annotations:
-    storageclass.kubevirt.io/is-default-virt-class: "true"
+  # annotations:
+  #   storageclass.kubevirt.io/is-default-virt-class: "true"
 parameters:
   volBackendFs: {{ gpfs_fs_name }}
 provisioner: spectrumscale.csi.ibm.com

--- a/templates/virt-hyperconverged.yaml
+++ b/templates/virt-hyperconverged.yaml
@@ -25,7 +25,8 @@ spec:
     completionTimeoutPerGiB: 800
     parallelMigrationsPerCluster: 5
     parallelOutboundMigrationsPerNode: 2
-    progressTimeout: 150
+    progressTimeout: 7200
+    allowPostCopy: true
   uninstallStrategy: BlockUninstallIfWorkloadsExist
   workloadUpdateStrategy:
     batchEvictionInterval: 1m0s

--- a/templates/virt-ns.yaml
+++ b/templates/virt-ns.yaml
@@ -1,0 +1,6 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: "{{ virt_test_ns }}"
+spec:

--- a/templates/virt-ssh-secret.yaml
+++ b/templates/virt-ssh-secret.yaml
@@ -2,7 +2,7 @@ kind: Secret
 apiVersion: v1
 metadata:
   name: vm-ssh
-  namespace: default
+  namespace: "{{ virt_test_ns }}"
 data:
   key: {{ ssh_pubkey | b64encode }}
 type: Opaque

--- a/templates/virt-ssh-secret.yaml
+++ b/templates/virt-ssh-secret.yaml
@@ -1,0 +1,9 @@
+kind: Secret
+apiVersion: v1
+metadata:
+  name: vm-ssh
+  namespace: default
+data:
+  key: {{ ssh_pubkey | b64encode }}
+type: Opaque
+

--- a/templates/virt-vm-cloudinit.yaml
+++ b/templates/virt-vm-cloudinit.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: vm-cloudinit
-  namespace: default
+  namespace: "{{ virt_test_ns }}"
 type: Opaque
 stringData:
   userdata: |

--- a/templates/virt-vm-cloudinit.yaml
+++ b/templates/virt-vm-cloudinit.yaml
@@ -13,6 +13,8 @@ stringData:
     user: fedora
     packages:
     - tmux
+    - vim
+    - libpq
     users: 
     - name: root
       ssh_authorized_keys:
@@ -50,3 +52,4 @@ stringData:
       ssh-keygen -t rsa -b 4096 -f /root/.ssh/id_rsa -N ''
       cat /root/.ssh/id_rsa.pub >> /root/.ssh/authorized_keys
       ssh-keyscan -H 127.0.0.1 >> ~/.ssh/known_hosts
+      dnf remove -y setroubleshoot-server

--- a/templates/virt-vm-cloudinit.yaml
+++ b/templates/virt-vm-cloudinit.yaml
@@ -1,0 +1,52 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: vm-cloudinit
+  namespace: default
+type: Opaque
+stringData:
+  userdata: |
+    #cloud-config
+    chpasswd:
+      expire: false
+    password: {{ vmpass }}
+    user: fedora
+    packages:
+    - tmux
+    users: 
+    - name: root
+      ssh_authorized_keys:
+        - ssh-rsa {{ ssh_pubkey }}
+    # write_files:
+    # - path: /root/.ssh/authorized_keys
+    #   owner: root:root
+    #   permissions: '0600'
+    #   content: |
+    # ssh:
+    #   ssh_pwauth: 1
+    #   disable_root: 0
+    runcmd: 
+    - |
+      #!/bin/bash
+      set -x
+      MAX_RETRIES=5
+      RETRY_INTERVAL=10  # seconds
+      URL="{{ dbperf_tar }}"
+
+      for ((i=1; i<=MAX_RETRIES; i++)); do
+        echo "Attempt $i: curl $URL"
+        curl -fsSL -o /tmp/kit.tar "$URL" && break
+        echo "Failed attempt $i. Retrying in $RETRY_INTERVAL seconds..."
+        sleep "$RETRY_INTERVAL"
+      done
+
+      if [ $i -gt $MAX_RETRIES ]; then
+        echo "All $MAX_RETRIES attempts failed." >&2
+        exit 1
+      fi
+      tar xf /tmp/kit.tar -C /root
+      sed -i -s 's,http://perf1.perf.eng.bos2.dc.redhat.com/sanjay/shak/HammerDB,https://acksyn.org/stuff,g' /root/hammerdb-tpcc-wrapper-scripts/*install-script
+      sed -i '/Please/d' /root/.ssh/authorized_keys
+      ssh-keygen -t rsa -b 4096 -f /root/.ssh/id_rsa -N ''
+      cat /root/.ssh/id_rsa.pub >> /root/.ssh/authorized_keys
+      ssh-keyscan -H 127.0.0.1 >> ~/.ssh/known_hosts

--- a/templates/virt-vm-db-service.yaml
+++ b/templates/virt-vm-db-service.yaml
@@ -9,4 +9,4 @@ spec:
       port: 3306
       targetPort: 3306
   selector:
-    app: fedora-db
+    app: centos-db

--- a/templates/virt-vm-db-service.yaml
+++ b/templates/virt-vm-db-service.yaml
@@ -1,0 +1,12 @@
+kind: Service
+apiVersion: v1
+metadata:
+  name: mariadb
+  namespace: default
+spec:
+  ports:
+    - protocol: TCP
+      port: 3306
+      targetPort: 3306
+  selector:
+    app: fedora-db

--- a/templates/virt-vm-db-service.yaml
+++ b/templates/virt-vm-db-service.yaml
@@ -2,7 +2,7 @@ kind: Service
 apiVersion: v1
 metadata:
   name: mariadb
-  namespace: default
+  namespace: "{{ virt_test_ns }}"
 spec:
   ports:
     - protocol: TCP

--- a/templates/virt-vm-db.yaml
+++ b/templates/virt-vm-db.yaml
@@ -14,14 +14,14 @@ spec:
         storage:
           resources:
             requests:
-              storage: '64087042032'
+              storage: '164087042032'
           storageClassName: ibm-test-sc
   instancetype:
     kind: virtualmachineclusterinstancetype
     name: u1.2xlarge
   preference:
     kind: virtualmachineclusterpreference
-    name: centos
+    name: centos.stream10
   runStrategy: Always
   template:
     metadata:

--- a/templates/virt-vm-db.yaml
+++ b/templates/virt-vm-db.yaml
@@ -1,33 +1,33 @@
 apiVersion: kubevirt.io/v1
 kind: VirtualMachine
 metadata:
-  name: fedora-db
+  name: centos-db
 spec:
   dataVolumeTemplates:
     - metadata:
-        name: fedora-db-volume
+        name: centos-db-volume
       spec:
         sourceRef:
           kind: DataSource
-          name: fedora
+          name: centos-stream10
           namespace: openshift-virtualization-os-images
         storage:
           resources:
             requests:
-              storage: '34087042032'
+              storage: '64087042032'
           storageClassName: ibm-test-sc
   instancetype:
     kind: virtualmachineclusterinstancetype
     name: u1.2xlarge
   preference:
     kind: virtualmachineclusterpreference
-    name: fedora
+    name: centos
   runStrategy: Always
   template:
     metadata:
       labels:
         network.kubevirt.io/headlessService: headless
-        app: fedora-db
+        app: centos-db
     spec:
       accessCredentials:
         - sshPublicKey:
@@ -52,7 +52,7 @@ spec:
       subdomain: headless
       volumes:
         - dataVolume:
-            name: fedora-db-volume
+            name: centos-db-volume
           name: rootdisk
         - name: cloudinitdisk
           cloudInitNoCloud:

--- a/templates/virt-vm-db.yaml
+++ b/templates/virt-vm-db.yaml
@@ -1,0 +1,60 @@
+apiVersion: kubevirt.io/v1
+kind: VirtualMachine
+metadata:
+  name: fedora-db
+spec:
+  dataVolumeTemplates:
+    - metadata:
+        name: fedora-db-volume
+      spec:
+        sourceRef:
+          kind: DataSource
+          name: fedora
+          namespace: openshift-virtualization-os-images
+        storage:
+          resources:
+            requests:
+              storage: '34087042032'
+          storageClassName: ibm-test-sc
+  instancetype:
+    kind: virtualmachineclusterinstancetype
+    name: u1.2xlarge
+  preference:
+    kind: virtualmachineclusterpreference
+    name: fedora
+  runStrategy: Always
+  template:
+    metadata:
+      labels:
+        network.kubevirt.io/headlessService: headless
+        app: fedora-db
+    spec:
+      accessCredentials:
+        - sshPublicKey:
+            propagationMethod:
+              noCloud: {}
+            source:
+              secret:
+                secretName: vm-ssh
+      architecture: amd64
+      domain:
+        devices:
+          autoattachPodInterface: false
+          interfaces:
+            - masquerade: {}
+              name: default
+        machine:
+          type: pc-q35-rhel9.4.0
+        resources: {}
+      networks:
+        - name: default
+          pod: {}
+      subdomain: headless
+      volumes:
+        - dataVolume:
+            name: fedora-db-volume
+          name: rootdisk
+        - name: cloudinitdisk
+          cloudInitNoCloud:
+            secretRef:
+              name: vm-cloudinit

--- a/templates/virt-vm-db.yaml
+++ b/templates/virt-vm-db.yaml
@@ -2,6 +2,7 @@ apiVersion: kubevirt.io/v1
 kind: VirtualMachine
 metadata:
   name: centos-db
+  namespace: "{{ virt_test_ns }}"
 spec:
   dataVolumeTemplates:
     - metadata:


### PR DESCRIPTION
- **Start adding virt bits for db**
- **Bigger disk and move to centos**
- **Fix centos**
- **Tweak HCO for better migration perf**
- **For now comment the default annotation and let default virt images go to gp3-csi**
- **Drop tag**
- **Switch to virt-test ns for vms**

## Summary by Sourcery

Set up virtualization infrastructure for a database environment, including VM configuration, networking, and performance optimizations

New Features:
- Create virtualized database VM with CentOS Stream 10
- Set up dedicated namespace for virtualization testing

Enhancements:
- Optimize KubeVirt migration performance by adjusting timeout and enabling post-copy migration
- Increase VM disk size to 164GB

Chores:
- Comment out default storage class annotation
- Switch to a new virtualization test namespace