### PR TITLE
virt work2

### DIFF
--- a/templates/storageclass.yaml
+++ b/templates/storageclass.yaml
@@ -2,8 +2,8 @@ apiVersion: storage.k8s.io/v1
 kind: StorageClass
 metadata:
   name: ibm-test-sc
-  # annotations:
-  #   storageclass.kubevirt.io/is-default-virt-class: "true"
+  annotations:
+    storageclass.kubevirt.io/is-default-virt-class: "true"
 parameters:
   volBackendFs: {{ gpfs_fs_name }}
 provisioner: spectrumscale.csi.ibm.com

--- a/templates/virt-hyperconverged.yaml
+++ b/templates/virt-hyperconverged.yaml
@@ -10,6 +10,13 @@ metadata:
   name: kubevirt-hyperconverged
   namespace: openshift-cnv
 spec:
+  logVerbosityConfig:
+    kubevirt:
+      virtLauncher: 5
+      virtHandler: 5
+      virtController: 5
+      virtAPI: 5
+      virtOperator: 5
   certConfig:
     ca:
       duration: 48h0m0s


### PR DESCRIPTION
- **Use ibm-sc as default virt sc**
- **Add some debugging to the HCO**

## Summary by Sourcery

Configure IBM storage class as the default virtualization storage class and add verbose logging for KubeVirt components

New Features:
- Set IBM storage class as the default virtualization storage class

Enhancements:
- Increase logging verbosity for KubeVirt components to level 5 for improved debugging