### PR TITLE
Grafana support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -35,6 +35,10 @@ virt: ## Configures the virt bits (only for POWER90)
 	@if [ "$(POWER90)" = "false" ]; then echo "Error, virt is only for power90"; exit 1; fi
 	ansible-playbook -i hosts $(TAGS_STRING) $(EXTRA_ARGS) $(EXTRA_VARS) playbooks/virt.yml
 
+.PHONY: grafana
+grafana: ## Configures the grafana bits
+	ansible-playbook -i hosts $(TAGS_STRING) $(EXTRA_ARGS) $(EXTRA_VARS) playbooks/grafana.yml
+
 .PHONY: gpfs-cleanup
 gpfs-cleanup: ## Deletes all the GPFS objects (https://www.ibm.com/docs/en/scalecontainernative/5.2.2?topic=cleanup-red-hat-openshift-nodes)
 	ansible-playbook -i hosts $(TAGS_STRING) $(EXTRA_ARGS) $(EXTRA_VARS) playbooks/gpfs-cleanup.yml

--- a/group_vars/all
+++ b/group_vars/all
@@ -32,8 +32,9 @@ gpfs_volume_name: "gpfs-volume"
 gpfs_shared_lun: "/dev/nvme1n1"
 # Version installed when using the openshift-fusion-access operator
 gpfs_cnsa_version: "v5.2.3.0.rc1"
-
 gpfs_fs_name: "localfilesystem1"
+
+grafana_ns: "grafana-for-cnsa"
 
 operator_name: openshift-fusion-access-operator
 operator_namespace: openshift-fusion-access

--- a/group_vars/all
+++ b/group_vars/all
@@ -35,6 +35,7 @@ gpfs_cnsa_version: "v5.2.3.0.rc1"
 gpfs_fs_name: "localfilesystem1"
 
 grafana_ns: "grafana-for-cnsa"
+grafana_url: "https://raw.githubusercontent.com/IBM/ibm-spectrum-scale-bridge-for-grafana/master/examples/openshift_deployment_scripts/examples_for_grafana-operator_v5/"
 
 operator_name: openshift-fusion-access-operator
 operator_namespace: openshift-fusion-access

--- a/playbooks/grafana.yml
+++ b/playbooks/grafana.yml
@@ -22,16 +22,16 @@
         set -ex
         oc patch cluster ibm-spectrum-scale --type merge --patch '{"spec": {"grafanaBridge": {"nodeSelector": {"scale.spectrum.ibm.com/daemon-selector": ""}}}}'
         oc new-project {{ grafana_ns }}
-        oc apply -f https://raw.githubusercontent.com/IBM/ibm-spectrum-scale-bridge-for-grafana/master/examples/openshift_deployment_scripts/examples_for_grafana-operator_v5/grafana_deployment/operator-group-v5.yaml --namespace={{ grafana_ns }}
-        oc apply -f https://raw.githubusercontent.com/IBM/ibm-spectrum-scale-bridge-for-grafana/master/examples/openshift_deployment_scripts/examples_for_grafana-operator_v5/grafana_deployment/subscription-grafana-operator-v5.yaml --namespace={{ grafana_ns }}  
-        oc apply -f https://raw.githubusercontent.com/IBM/ibm-spectrum-scale-bridge-for-grafana/master/examples/openshift_deployment_scripts/examples_for_grafana-operator_v5/grafana_deployment/grafana-instance-for-cnsa-v5.yaml --namespace={{ grafana_ns }}
+        oc apply -f {{ grafana_url }}/examples_for_grafana-operator_v5/grafana_deployment/operator-group-v5.yaml --namespace={{ grafana_ns }}
+        oc apply -f {{ grafana_url }}/examples_for_grafana-operator_v5/grafana_deployment/subscription-grafana-operator-v5.yaml --namespace={{ grafana_ns }}  
+        oc apply -f {{ grafana_url }}/examples_for_grafana-operator_v5/grafana_deployment/grafana-instance-for-cnsa-v5.yaml --namespace={{ grafana_ns }}
         oc adm policy add-cluster-role-to-user ibm-spectrum-scale-operator -z grafana-for-cnsa-sa
-        oc apply -f https://raw.githubusercontent.com/IBM/ibm-spectrum-scale-bridge-for-grafana/master/examples/openshift_deployment_scripts/examples_for_grafana-operator_v5/grafana_datasource_deployment/bridge-tls-secret-v5.yaml --namespace={{ grafana_ns }}
+        oc apply -f {{ grafana_url }}/examples_for_grafana-operator_v5/grafana_datasource_deployment/bridge-tls-secret-v5.yaml --namespace={{ grafana_ns }}
         TLS_CERT=`oc get secret ibm-spectrum-scale-grafana-bridge-service-cert -n ibm-spectrum-scale -o json |jq '.data["tls.crt"]' | tr -d \"`
         TLS_KEY=`oc get secret ibm-spectrum-scale-grafana-bridge-service-cert -n ibm-spectrum-scale -o json |jq '.data["tls.key"]' | tr -d \"`
         oc get secrets grafana-bridge-tls-cert -n {{ grafana_ns }} -o json | jq ".data[\"tls.key\"] |= \"$TLS_KEY\"" | jq ".data[\"tls.crt\"] |= \"$TLS_CERT\""| oc apply -f -
-        oc apply -f https://raw.githubusercontent.com/IBM/ibm-spectrum-scale-bridge-for-grafana/master/examples/openshift_deployment_scripts/examples_for_grafana-operator_v5/grafana_datasource_deployment/grafana-bridge-datasource-v5.yaml --namespace={{ grafana_ns }}
+        oc apply -f {{ grafana_url }}/examples_for_grafana-operator_v5/grafana_datasource_deployment/grafana-bridge-datasource-v5.yaml --namespace={{ grafana_ns }}
         # Check setup
         oc get GrafanaDataSource bridge-grafanadatasource -n {{ grafana_ns }} -o json | jq '.status'
-        oc apply -f https://raw.githubusercontent.com/IBM/ibm-spectrum-scale-bridge-for-grafana/master/examples/openshift_deployment_scripts/examples_for_grafana-operator_v5/provision_dashboard/cnsa-cluster-simple-dashboard-v5.yaml
+        oc apply -f {{ grafana_url }}/examples_for_grafana-operator_v5/provision_dashboard/cnsa-cluster-simple-dashboard-v5.yaml
 

--- a/playbooks/grafana.yml
+++ b/playbooks/grafana.yml
@@ -20,19 +20,18 @@
     - name: Grafana setup
       ansible.builtin.shell: |
         set -ex
-        export NAMESPACE=grafana-for-cnsa
         oc patch cluster ibm-spectrum-scale --type merge --patch '{"spec": {"grafanaBridge": {"nodeSelector": {"scale.spectrum.ibm.com/daemon-selector": ""}}}}'
-        oc new-project $NAMESPACE
-        oc apply -f https://raw.githubusercontent.com/IBM/ibm-spectrum-scale-bridge-for-grafana/master/examples/openshift_deployment_scripts/examples_for_grafana-operator_v5/grafana_deployment/operator-group-v5.yaml --namespace=$NAMESPACE
-        oc apply -f https://raw.githubusercontent.com/IBM/ibm-spectrum-scale-bridge-for-grafana/master/examples/openshift_deployment_scripts/examples_for_grafana-operator_v5/grafana_deployment/subscription-grafana-operator-v5.yaml --namespace=$NAMESPACE  
-        oc apply -f https://raw.githubusercontent.com/IBM/ibm-spectrum-scale-bridge-for-grafana/master/examples/openshift_deployment_scripts/examples_for_grafana-operator_v5/grafana_deployment/grafana-instance-for-cnsa-v5.yaml --namespace=$NAMESPACE
+        oc new-project {{ grafana_ns }}
+        oc apply -f https://raw.githubusercontent.com/IBM/ibm-spectrum-scale-bridge-for-grafana/master/examples/openshift_deployment_scripts/examples_for_grafana-operator_v5/grafana_deployment/operator-group-v5.yaml --namespace={{ grafana_ns }}
+        oc apply -f https://raw.githubusercontent.com/IBM/ibm-spectrum-scale-bridge-for-grafana/master/examples/openshift_deployment_scripts/examples_for_grafana-operator_v5/grafana_deployment/subscription-grafana-operator-v5.yaml --namespace={{ grafana_ns }}  
+        oc apply -f https://raw.githubusercontent.com/IBM/ibm-spectrum-scale-bridge-for-grafana/master/examples/openshift_deployment_scripts/examples_for_grafana-operator_v5/grafana_deployment/grafana-instance-for-cnsa-v5.yaml --namespace={{ grafana_ns }}
         oc adm policy add-cluster-role-to-user ibm-spectrum-scale-operator -z grafana-for-cnsa-sa
-        oc apply -f https://raw.githubusercontent.com/IBM/ibm-spectrum-scale-bridge-for-grafana/master/examples/openshift_deployment_scripts/examples_for_grafana-operator_v5/grafana_datasource_deployment/bridge-tls-secret-v5.yaml --namespace=$NAMESPACE
+        oc apply -f https://raw.githubusercontent.com/IBM/ibm-spectrum-scale-bridge-for-grafana/master/examples/openshift_deployment_scripts/examples_for_grafana-operator_v5/grafana_datasource_deployment/bridge-tls-secret-v5.yaml --namespace={{ grafana_ns }}
         TLS_CERT=`oc get secret ibm-spectrum-scale-grafana-bridge-service-cert -n ibm-spectrum-scale -o json |jq '.data["tls.crt"]' | tr -d \"`
         TLS_KEY=`oc get secret ibm-spectrum-scale-grafana-bridge-service-cert -n ibm-spectrum-scale -o json |jq '.data["tls.key"]' | tr -d \"`
-        oc get secrets grafana-bridge-tls-cert -n $NAMESPACE -o json | jq ".data[\"tls.key\"] |= \"$TLS_KEY\"" | jq ".data[\"tls.crt\"] |= \"$TLS_CERT\""| oc apply -f -
-        oc apply -f https://raw.githubusercontent.com/IBM/ibm-spectrum-scale-bridge-for-grafana/master/examples/openshift_deployment_scripts/examples_for_grafana-operator_v5/grafana_datasource_deployment/grafana-bridge-datasource-v5.yaml --namespace=$NAMESPACE
+        oc get secrets grafana-bridge-tls-cert -n {{ grafana_ns }} -o json | jq ".data[\"tls.key\"] |= \"$TLS_KEY\"" | jq ".data[\"tls.crt\"] |= \"$TLS_CERT\""| oc apply -f -
+        oc apply -f https://raw.githubusercontent.com/IBM/ibm-spectrum-scale-bridge-for-grafana/master/examples/openshift_deployment_scripts/examples_for_grafana-operator_v5/grafana_datasource_deployment/grafana-bridge-datasource-v5.yaml --namespace={{ grafana_ns }}
         # Check setup
-        oc get GrafanaDataSource bridge-grafanadatasource -n $NAMESPACE -o json | jq '.status'
+        oc get GrafanaDataSource bridge-grafanadatasource -n {{ grafana_ns }} -o json | jq '.status'
         oc apply -f https://raw.githubusercontent.com/IBM/ibm-spectrum-scale-bridge-for-grafana/master/examples/openshift_deployment_scripts/examples_for_grafana-operator_v5/provision_dashboard/cnsa-cluster-simple-dashboard-v5.yaml
 

--- a/playbooks/grafana.yml
+++ b/playbooks/grafana.yml
@@ -1,0 +1,38 @@
+---
+- name: Playbook to set up the grafana bridge
+  hosts: localhost
+  gather_facts: false
+  become: false
+  vars_files:
+    # Use this to override stuff that won't be committed to git
+    - ../overrides.yml
+  tasks:
+    - name: Print AWS infos
+      ansible.builtin.debug:
+        msg: "Region: {{ ocp_region }} - Cluster: {{ ocp_cluster_name }}.{{ ocp_domain }} - Workers [{{ ocp_worker_count }}]: {{ ocp_worker_type }}"
+
+    - name: Check if cluster has gpfs installed correctly
+      ansible.builtin.shell: |
+        set -ex
+        export KUBECONFIG={{ kubeconfig }}
+        oc get filesystems -A
+
+    - name: Grafana setup
+      ansible.builtin.shell: |
+        set -ex
+        export NAMESPACE=grafana-for-cnsa
+        oc patch cluster ibm-spectrum-scale --type merge --patch '{"spec": {"grafanaBridge": {"nodeSelector": {"scale.spectrum.ibm.com/daemon-selector": ""}}}}'
+        oc new-project $NAMESPACE
+        oc apply -f https://raw.githubusercontent.com/IBM/ibm-spectrum-scale-bridge-for-grafana/master/examples/openshift_deployment_scripts/examples_for_grafana-operator_v5/grafana_deployment/operator-group-v5.yaml --namespace=$NAMESPACE
+        oc apply -f https://raw.githubusercontent.com/IBM/ibm-spectrum-scale-bridge-for-grafana/master/examples/openshift_deployment_scripts/examples_for_grafana-operator_v5/grafana_deployment/subscription-grafana-operator-v5.yaml --namespace=$NAMESPACE  
+        oc apply -f https://raw.githubusercontent.com/IBM/ibm-spectrum-scale-bridge-for-grafana/master/examples/openshift_deployment_scripts/examples_for_grafana-operator_v5/grafana_deployment/grafana-instance-for-cnsa-v5.yaml --namespace=$NAMESPACE
+        oc adm policy add-cluster-role-to-user ibm-spectrum-scale-operator -z grafana-for-cnsa-sa
+        oc apply -f https://raw.githubusercontent.com/IBM/ibm-spectrum-scale-bridge-for-grafana/master/examples/openshift_deployment_scripts/examples_for_grafana-operator_v5/grafana_datasource_deployment/bridge-tls-secret-v5.yaml --namespace=$NAMESPACE
+        TLS_CERT=`oc get secret ibm-spectrum-scale-grafana-bridge-service-cert -n ibm-spectrum-scale -o json |jq '.data["tls.crt"]' | tr -d \"`
+        TLS_KEY=`oc get secret ibm-spectrum-scale-grafana-bridge-service-cert -n ibm-spectrum-scale -o json |jq '.data["tls.key"]' | tr -d \"`
+        oc get secrets grafana-bridge-tls-cert -n $NAMESPACE -o json | jq ".data[\"tls.key\"] |= \"$TLS_KEY\"" | jq ".data[\"tls.crt\"] |= \"$TLS_CERT\""| oc apply -f -
+        oc apply -f https://raw.githubusercontent.com/IBM/ibm-spectrum-scale-bridge-for-grafana/master/examples/openshift_deployment_scripts/examples_for_grafana-operator_v5/grafana_datasource_deployment/grafana-bridge-datasource-v5.yaml --namespace=$NAMESPACE
+        # Check setup
+        oc get GrafanaDataSource bridge-grafanadatasource -n $NAMESPACE -o json | jq '.status'
+        oc apply -f https://raw.githubusercontent.com/IBM/ibm-spectrum-scale-bridge-for-grafana/master/examples/openshift_deployment_scripts/examples_for_grafana-operator_v5/provision_dashboard/cnsa-cluster-simple-dashboard-v5.yaml
+


### PR DESCRIPTION
- **Add grafana bridge support**
- **Use ansible var for namespace**
- **Consolidate grafana files url**

## Summary by Sourcery

Add Grafana bridge support for IBM Spectrum Scale cluster monitoring

New Features:
- Implement Grafana integration for monitoring IBM Spectrum Scale clusters

Enhancements:
- Add a new Makefile target for Grafana configuration
- Introduce dynamic namespace configuration for Grafana deployment

Chores:
- Create a new Ansible playbook for Grafana setup