### PR TITLE
Some workarounds

### DIFF
--- a/playbooks/virt.yml
+++ b/playbooks/virt.yml
@@ -65,3 +65,18 @@
         - virt-vm-db-service.yaml
         - virt-vm-db.yaml
         - virt-vm-cloudinit.yaml
+
+    - name: Apply basic virt templates (except vm itself)
+      ansible.builtin.shell: |
+        set -e
+        export KUBECONFIG="{{ kubeconfig }}"
+        {{ oc_bin }} apply -f "{{ gpfsfolder }}/{{ item }}"
+      register: virt_apply
+      until: virt_apply is not failed
+      retries: 20
+      delay: 10
+      loop:
+        - virt-ns.yaml
+        - virt-ssh-secret.yaml
+        - virt-vm-db-service.yaml
+        - virt-vm-cloudinit.yaml

--- a/templates/virt-vm-db.yaml
+++ b/templates/virt-vm-db.yaml
@@ -7,6 +7,9 @@ spec:
   dataVolumeTemplates:
     - metadata:
         name: centos-db-volume
+        # Works around OCPNAS-60 for now
+        annotations:
+          cdi.kubevirt.io/cloneType: copy
       spec:
         sourceRef:
           kind: DataSource


### PR DESCRIPTION
- **Apply basic virt templates by default**
- **Add workaround for OCPNAS-60**

## Summary by Sourcery

Automate deployment of basic virtualization templates and apply a workaround for data volume cloning.

Bug Fixes:
- Add annotation to `virt-vm-db.yaml` to force 'copy' clone type, working around OCPNAS-60.

Deployment:
- Apply basic virt templates (namespace, secret, service, cloud-init) by default.