### PR TITLE
Add aws profile to openshift-install, fix condition for power90

### DIFF
--- a/playbooks/destroy.yml
+++ b/playbooks/destroy.yml
@@ -62,4 +62,4 @@
         id: "{{ item.id }}"
         state: absent
       loop: "{{ volume_info_two.volumes }}"
-      when: volume_info_two.volumes | length > 0
+      when: power_ninety | bool and volume_info_two.volumes | length > 0

--- a/playbooks/install.yml
+++ b/playbooks/install.yml
@@ -59,6 +59,8 @@
         {{ basefolder }}/{{ ocp_version }}/openshift-install create cluster --dir=. &> /tmp/oc-{{ ocp_version }}-{{ ocp_cluster_name }}.log
       args:
         chdir: "{{ ocpfolder }}"
+      environment:
+        AWS_PROFILE: "{{ aws_profile }}"
       when: not metadata_json_file.stat.exists
 
     - name: Does cluster kubeconfig exist


### PR DESCRIPTION
## Summary by Sourcery

Modify OpenShift installation playbooks to add AWS profile support and improve conditional volume deletion

Enhancements:
- Add AWS profile environment variable to OpenShift installation process

Chores:
- Update conditional logic for volume deletion to include power90 flag