### PR TITLE
Add missing aws_profile to ocp destroy

### DIFF
--- a/playbooks/destroy.yml
+++ b/playbooks/destroy.yml
@@ -19,6 +19,8 @@
         {{ basefolder }}/{{ ocp_version }}/openshift-install destroy cluster --dir=. &> /tmp/oc-{{ ocp_version }}-destroy.log
       args:
         chdir: "{{ ocpfolder }}"
+      environment:
+        AWS_PROFILE: "{{ aws_profile }}"
       when: metadata_json_file.stat.exists
 
     - name: Get the Volume ID by Tag Name


### PR DESCRIPTION
## Summary by Sourcery

Bug Fixes:
- Include AWS_PROFILE in the environment for the OCP destroy command to prevent failures when a default AWS profile is not set