### PR TITLE
Small dns fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ EBS volume and attach it to the three workers.
 3. Run the following to create an `overrides.yml`. 
 ```
 cat > overrides.yml<<EOF
-# ocp_domain: "aws.validatedpatterns.io"
+# ocp_domain: "fusionaccess.devcluster.openshift.com"
 ocp_cluster_name: "gpfs-bandini"
 gpfs_volume_name: "bandini-volume"
 # ocp_worker_count: 3

--- a/group_vars/all
+++ b/group_vars/all
@@ -4,7 +4,7 @@
 # ocp_version: "4.19.0-ec.5"
 ocp_version: "4.18.9"
 
-ocp_domain: "aws.validatedpatterns.io"
+ocp_domain: "fusionaccess.devcluster.openshift.com"
 ocp_cluster_name: "gpfs-test"
 ocp_worker_count: 3
 ocp_worker_type: "m5.2xlarge"

--- a/playbooks/install.yml
+++ b/playbooks/install.yml
@@ -11,7 +11,7 @@
       tags:
         - 1_ocp_install
       ansible.builtin.debug:
-        msg: "Region: {{ ocp_region }} - Cluster: {{ ocp_cluster_name }}.{{ ocp_domain }} - Workers [{{ ocp_worker_count }}]: {{ ocp_worker_type }}"
+        msg: "Region: {{ ocp_region }} - Cluster: {{ ocp_cluster_name }}.{{ ocp_domain }} - Workers [{{ ocp_worker_count }}]: {{ ocp_worker_type }} - AWS Profile: {{ aws_profile }}"
 
     - name: Check if the ibm-entitlement file exists
       tags:

--- a/vars/power90.yaml
+++ b/vars/power90.yaml
@@ -5,7 +5,6 @@ ocp_worker_type: m5.metal
 ocp_master_type: m5.4xlarge
 ocp_az: eu-north-1a
 ocp_region: eu-north-1
-aws_profile: default
 
 gpfs_volume_name_two: "gpfs-volume-fast"
 ebs_volume_size_two: 310


### PR DESCRIPTION
## Summary by Sourcery

Update DNS sample configuration and refine AWS profile handling across documentation and playbooks

Bug Fixes:
- Correct the example `ocp_domain` value in the README

Enhancements:
- Add AWS profile display to the installation debug message
- Remove the default `aws_profile` from the `power90.yaml` variables to centralize configuration