### PR TITLE
Test for htpasswd command presence

### DIFF
--- a/playbooks/install.yml
+++ b/playbooks/install.yml
@@ -13,6 +13,14 @@
       ansible.builtin.debug:
         msg: "Region: {{ ocp_region }} - Cluster: {{ ocp_cluster_name }}.{{ ocp_domain }} - Workers [{{ ocp_worker_count }}]: {{ ocp_worker_type }} - AWS Profile: {{ aws_profile }}"
 
+    - name: Verify htpasswd exists
+      ansible.builtin.command:
+        cmd: which htpasswd
+      register: htpasswd_check
+      failed_when: htpasswd_check.rc != 0
+      tags:
+        - 1_ocp_install
+
     - name: Check if the ibm-entitlement file exists
       tags:
         - 1_ocp_install


### PR DESCRIPTION
## Summary by Sourcery

Add pre-install Ansible tasks to verify that the ‘htpasswd’ command is available and fail early if it is not installed.

Enhancements:
- Introduce a shell check for the ‘htpasswd’ command before installation steps
- Abort the playbook with a clear error message when ‘htpasswd’ is missing