### PR TITLE
Create gpfs folder before rendering the mco file

### DIFF
--- a/playbooks/install.yml
+++ b/playbooks/install.yml
@@ -110,6 +110,14 @@
             export KUBECONFIG={{ kubeconfig }}
             {{ oc_bin }} patch secret -n kube-system kubeadmin --type json -p '[{"op": "replace", "path": "/data/kubeadmin", "value": "'{{ hashed_password }}'"}]'
 
+    - name: Create gpfs folder
+      tags:
+        - 1_ocp_install_mco
+      ansible.builtin.file:
+        path: "{{ gpfsfolder }}"
+        state: directory
+        recurse: true
+
     - name: Template mco file
       tags:
         - 1_ocp_install_mco

--- a/playbooks/operator-install.yml
+++ b/playbooks/operator-install.yml
@@ -1,11 +1,3 @@
-- name: Create gpfs folder
-  tags:
-    - 4_operator
-  ansible.builtin.file:
-    path: "{{ gpfsfolder }}"
-    state: directory
-    recurse: true
-
 - name: Template catalogsource
   ansible.builtin.template:
     src: ../templates/operator-catalog.yaml


### PR DESCRIPTION
## Summary by Sourcery

Enhancements:
- Relocate the GPFS folder creation task from operator-install.yml to playbooks/install.yml before templating the MCO file