### PR TITLE
Enhances OS and CPU architecture detection

### DIFF
--- a/group_vars/all
+++ b/group_vars/all
@@ -1,8 +1,33 @@
 ---
+cpu_arch: >-
+  {%- if ansible_architecture == "aarch64" -%}
+    arm64
+  {%- else -%}
+    {{ ansible_architecture }}
+  {%- endif -%}
+os_group: >-
+  {%- if ansible_system == "Darwin" -%}
+    mac
+  {%- elif ansible_system == "Linux" -%}
+    linux
+  {%- else -%}
+    EOSGROUPNA
+  {%- endif -%}
+butane_os_group: >-
+  {%- if os_group == "mac" -%}
+    -darwin
+  {%- elif os_group == "linux" -%}
+  {%- else -%}
+    EBUTANEOSNA
+  {%- endif -%}
+
+
 # Default version to be used, run "make ocp-versions" to see which are the latest
 # ones and download them with "make ocp-clients"
 # ocp_version: "4.19.0-ec.5"
 ocp_version: "4.18.9"
+# For Dev-preview just use: "ocp-dev-preview", the rest of the URL segments remain the same.
+ocp_channel: "ocp"
 
 ocp_domain: "fusionaccess.devcluster.openshift.com"
 ocp_cluster_name: "gpfs-test"
@@ -50,13 +75,13 @@ basefolder: "{{ '~/aws-gpfs-playground' | expanduser }}"
 ocpfolder: "{{ basefolder }}/ocp_install_files"
 oc_bin: "{{ basefolder }}/{{ ocp_version }}/oc"
 butane_ver: "v0.23.0-0"
-butane_url: "https://mirror.openshift.com/pub/openshift-v4/clients/butane/{{ butane_ver }}/butane-amd64"
+butane_url: "{{ openshift_mirror }}/clients/butane/{{ butane_ver }}/butane{{ butane_os_group }}-{{ ansible_architecture  }}"
 butane_bin: "{{ basefolder }}/{{ ocp_version }}/butane"
 virtctl_bin: "{{ basefolder }}/{{ ocp_version }}/virtctl"
 kubeconfig: "{{ ocpfolder }}/auth/kubeconfig"
 gpfsfolder: "{{ basefolder }}/gpfs"
 tempfolder: "/tmp/aws-gpfs-temp-folder"
-openshift_mirror: "{{ 'https://mirror.openshift.com/pub/openshift-v4/x86_64/clients/ocp-dev-preview' if '-ec' in ocp_version else 'https://mirror.openshift.com/pub/openshift-v4/clients/ocp' }}"
+openshift_mirror: "https://mirror.openshift.com/pub/openshift-v4"
 pullsecret: "{{ lookup('file', '~/.pullsecret.json' | expanduser) }}"
 
 ibmentitlementkeyfile: "{{ '~/.ibm-entitlement-key' | expanduser }}"

--- a/playbooks/ocp-clients.yml
+++ b/playbooks/ocp-clients.yml
@@ -7,23 +7,24 @@
     # Use this to override stuff that won't be committed to git
     - ../overrides.yml
   tasks:
+    - debug:
+        msg:
+          Environment:
+            Architecture: "{{ cpu_arch }}"
+            OCP version: "{{ ocp_version }}"
+            OCP channel: "{{ ocp_channel }}"
+            OS: "{{ os_group }}"
+    
     - name: Create mirror folders
       ansible.builtin.file:
         path: "{{ basefolder }}/{{ ocp_version }}"
         state: directory
         recurse: true
 
-    - name: Set OC facts to download bits (Mac OSX)
-      ansible.builtin.set_fact:
-        oc_client_url: "{{ openshift_mirror }}/{{ ocp_version }}/openshift-client-mac-arm64.tar.gz"
-        oc_install_url: "{{ openshift_mirror }}/{{ ocp_version }}/openshift-install-mac-arm64.tar.gz"
-      when: ansible_facts['os_family'] == "Darwin"
-
     - name: Set OC facts to download bits (Linux)
       ansible.builtin.set_fact:
-        oc_client_url: "{{ openshift_mirror }}/{{ ocp_version }}/openshift-client-linux.tar.gz"
-        oc_install_url: "{{ openshift_mirror }}/{{ ocp_version }}/openshift-install-linux.tar.gz"
-      when: ansible_facts['os_family'] == "RedHat" or ansible_facts['os_family'] == "Debian"
+        oc_client_url: "{{ openshift_mirror }}/multi/clients/{{ ocp_channel }}/{{ ocp_version }}/{{ cpu_arch }}/openshift-client-{{ os_group }}.tar.gz"
+        oc_install_url: "{{ openshift_mirror }}/multi/clients/{{ ocp_channel }}/{{ ocp_version }}/{{ cpu_arch }}/openshift-install-{{ os_group }}.tar.gz"
 
     - name: Print URLs
       ansible.builtin.debug:
@@ -59,8 +60,13 @@
         dest: "{{ basefolder }}/{{ ocp_version }}"
         remote_src: true
 
-    - name: Uncompress openshift install
+    - name: Uncompress openshift-install
       ansible.builtin.unarchive:
         src: "{{ basefolder }}/{{ ocp_version }}/openshift-install.tar.gz"
         dest: "{{ basefolder }}/{{ ocp_version }}"
         remote_src: true
+    
+    - name: Remove *.tar.gz files
+      ansible.builtin.file:
+        path: "{{ basefolder }}/{{ ocp_version }}/openshift-*.tar.gz"
+        state: absent


### PR DESCRIPTION
Updates binaries' download URLs based on that information

Signed-off-by: Jonathan Kilzi <jkilzi@redhat.com>

## Summary by Sourcery

Enhance OS and CPU architecture detection in the ocp-clients playbook to generate download URLs dynamically and clean up artifacts after extraction

Enhancements:
- Add a debug task to display environment details including OS, CPU architecture, OCP version, and channel
- Replace static URL logic with dynamic construction using cpu_arch, os_group, ocp_version, and ocp_channel
- Remove hardcoded Mac OSX download configuration and unify client/install URL tasks
- Add a cleanup task to remove downloaded tar.gz archives after extraction
- Rename the unarchive task for openshift-install to improve clarity