### PR TITLE
4.19.0-rc.3 as a default

### DIFF
--- a/group_vars/all
+++ b/group_vars/all
@@ -33,7 +33,7 @@ butane_arch: >-
 # Default version to be used, run "make ocp-versions" to see which are the latest
 # ones and download them with "make ocp-clients"
 # ocp_version: "4.19.0-ec.5"
-ocp_version: "4.18.9"
+ocp_version: "4.19.0-rc.3"
 # For Dev-preview just use: "ocp-dev-preview", the rest of the URL segments remain the same.
 ocp_channel: "ocp"
 


### PR DESCRIPTION
## Summary by Sourcery

Enhancements:
- Bump default kernel version to 4.19.0-rc.3 in group_vars/all