### PR TITLE
Add iscsi playbooks and make targets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -52,6 +52,14 @@ destroy: ## Destroy installed AWS cluster
 	ansible-playbook -i hosts $(TAGS_STRING) $(EXTRA_ARGS) $(EXTRA_VARS) playbooks/destroy.yml
 	-@notify.sh "AWS destroy finished"
 
+.PHONY: iscsi
+iscsi: ## Creates iscsi ec2 target and connects it to worker nodes
+	ansible-playbook -i hosts $(TAGS_STRING) $(EXTRA_ARGS) $(EXTRA_VARS) playbooks/iscsi.yml
+
+.PHONY: iscsi-cleanup
+iscsi-cleanup: ## Removes iscsi ec2 resources
+	ansible-playbook -i hosts $(TAGS_STRING) $(EXTRA_ARGS) $(EXTRA_VARS) playbooks/iscsi-cleanup.yml
+
 .PHONY: list-tags
 list-tags: ## Lists all tags in the install playbook
 	ansible-playbook --list-tags playbooks/install.yml

--- a/group_vars/all
+++ b/group_vars/all
@@ -100,3 +100,11 @@ power_ninety: false
 vmpass: "{{ lookup('file', '~/.vmpass' | expanduser) }}"
 dbperf_tar: "https://acksyn.org/stuff/hammerdb-tpcc-wrapper-scripts-kit.tar"
 virt_test_ns: "virt-test"
+
+iscsi_target_iqn: iqn.2024-02.com.example
+iscsi_target_primary_ip: 10.0.100.100
+iscsi_target_secondary_ip: 10.0.100.101
+iscsi_target_ami_image_id: ami-00187b27c7593c902 # fedora41
+iscsi_target_ssh_key_name: aeros-ssh-key-rsa
+iscsi_target_volume_size: 150 # in GB
+iscsi_target_instance_type: t2.micro

--- a/playbooks/iscsi-cleanup.yml
+++ b/playbooks/iscsi-cleanup.yml
@@ -1,0 +1,49 @@
+---
+- name: Playbook to set up the iscsi target ec2 in aws
+  hosts: localhost
+  gather_facts: false
+  become: false
+  vars_files:
+    # Use this to override stuff that won't be committed to git
+    - ../overrides.yml
+  vars:
+    iscsi_target_ssh_key_name: aeros-ssh-key-rsa
+
+  tasks:
+    - name: Print AWS infos
+      ansible.builtin.debug:
+        msg: "Region: {{ ocp_region }} - Cluster: {{ ocp_cluster_name }}.{{ ocp_domain }} - Workers [{{ ocp_worker_count }}]: {{ ocp_worker_type }} - AWS Profile: {{ aws_profile }}"
+
+    - name: Delete created key pair
+      amazon.aws.ec2_key:
+        profile: "{{ aws_profile }}"
+        region: "{{ ocp_region }}"
+        name: "{{ iscsi_target_ssh_key_name }}"
+        state: absent
+
+    - name: Gather the ec2 instance details
+      amazon.aws.ec2_instance_info:
+        profile: "{{ aws_profile }}"
+        region: "{{ ocp_region }}"
+        filters:
+          "tag:Name": "iscsi-target"
+      register: ec2_node_info
+
+    - name: Set ec2 instance id
+      ansible.builtin.set_fact:
+        instance_id: "{{ ec2_node_info.instances | map(attribute='instance_id') | first  }}"
+
+    - name: Delete ec2 instance
+      amazon.aws.ec2_instance:
+        profile: "{{ aws_profile }}"
+        region: "{{ ocp_region }}"
+        instance_ids:
+          - "{{ instance_id }}"
+        state: terminated
+
+    - name: Delete ec2 security group
+      amazon.aws.ec2_security_group:
+        profile: "{{ aws_profile }}"
+        region: "{{ ocp_region }}"
+        name: iscsi-target-security-group
+        state: absent

--- a/playbooks/iscsi.yml
+++ b/playbooks/iscsi.yml
@@ -1,0 +1,114 @@
+---
+- name: Playbook to set up the iscsi target ec2 in aws
+  hosts: localhost
+  gather_facts: false
+  become: false
+  vars_files:
+    # Use this to override stuff that won't be committed to git
+    - ../overrides.yml
+
+  tasks:
+    - name: Print AWS infos
+      ansible.builtin.debug:
+        msg: "Region: {{ ocp_region }} - Cluster: {{ ocp_cluster_name }}.{{ ocp_domain }} - Workers [{{ ocp_worker_count }}]: {{ ocp_worker_type }} - AWS Profile: {{ aws_profile }}"
+
+    - name: Create key pair to access ec2 with ssh
+      amazon.aws.ec2_key:
+        profile: "{{ aws_profile }}"
+        region: "{{ ocp_region }}"
+        name: "{{ iscsi_target_ssh_key_name }}"
+        key_material: "{{ ssh_pubkey }}"
+
+    - name: Gather security group info for workers
+      amazon.aws.ec2_security_group_info:
+        profile: "{{ aws_profile }}"
+        region: "{{ ocp_region }}"
+        filters:
+          "tag:sigs.k8s.io/cluster-api-provider-aws/role": "node"
+      register: sg_info
+
+    - name: Set vpc and sg id
+      ansible.builtin.set_fact:
+        sg_vpc_id: "{{ sg_info.security_groups[0].vpc_id }}"
+        sg_group_id: "{{ sg_info.security_groups[0].group_id }}"
+
+    - name: Gather vpc info for workers
+      amazon.aws.ec2_vpc_subnet_info:
+        profile: "{{ aws_profile }}"
+        region: "{{ ocp_region }}"
+        filters:
+          vpc-id: "{{ sg_vpc_id }}"
+      register: subnet_info
+
+    - name: Set public subnet id
+      ansible.builtin.set_fact: # only add the public subnet, and there will be only exactly one
+        public_subnet_id: "{{ subnet_info.subnets |  selectattr('map_public_ip_on_launch', '==', true) | map(attribute='subnet_id') | first }}"
+
+    - name: Create ec2 security group
+      amazon.aws.ec2_security_group:
+        profile: "{{ aws_profile }}"
+        region: "{{ ocp_region }}"
+        name: iscsi-target-security-group
+        description: sec group for iscsi target ec2
+        vpc_id: "{{ sg_vpc_id }}"
+        rules:
+        - proto: tcp
+          ports:
+            - 22
+          group_id: "{{ sg_group_id }}"
+          rule_desc: allow ssh from the ocp workers to debug
+        - proto: tcp
+          ports:
+            - 3260
+          group_id: "{{ sg_group_id }}"
+          rule_desc: allow iscsi for ocp worker nodes
+
+    - name: Start an instance with EBS
+      amazon.aws.ec2_instance:
+        profile: "{{ aws_profile }}"
+        region: "{{ ocp_region }}"
+        name: "iscsi-target"
+        state: started
+        wait: true
+        vpc_subnet_id: "{{ public_subnet_id }}"
+        instance_type: "{{ iscsi_target_instance_type }}"
+        key_name: "{{ iscsi_target_ssh_key_name }}"
+        security_group: iscsi-target-security-group
+        network_interfaces:
+          - assign_public_ip: false
+            private_ip_addresses:
+            - primary: true
+              private_ip_address: "{{ iscsi_target_primary_ip }}"
+            - primary: false
+              private_ip_address: "{{ iscsi_target_secondary_ip }}"
+        image_id: "{{ iscsi_target_ami_image_id }}"
+        volumes:
+          - device_name: /dev/sdb
+            ebs:
+              volume_size: "{{ iscsi_target_volume_size }}"
+              delete_on_termination: true
+        user_data: |
+          #!/bin/bash
+          sudo dnf install targetcli -y
+          sudo systemctl start target
+          sudo systemctl enable target
+          sudo targetcli backstores/block create name=block_backend dev=/dev/xvdb
+          sudo targetcli iscsi/ create {{ iscsi_target_iqn }}
+          sudo targetcli iscsi/{{ iscsi_target_iqn }}/tpg1/luns/ create /backstores/block/block_backend
+          sudo targetcli iscsi/{{ iscsi_target_iqn }}/tpg1/ set attribute generate_node_acls=1  authentication=0 demo_mode_write_protect=0 cache_dynamic_acls=1
+          sudo targetcli saveconfig
+
+    - name: Template mco file (iscsi)
+      ansible.builtin.template:
+        src: ../templates/mco-iscsi-multipath.yaml
+        dest: "{{ gpfsfolder }}/mco-iscsi-multipath.yaml"
+
+    - name: Template mco file (iscsi)
+      ansible.builtin.shell: |
+        {{ butane_bin }} "{{ gpfsfolder }}/mco-iscsi-multipath.yaml" -o "{{ gpfsfolder }}/99-mco-iscsi-multipath-butaned.yaml"
+
+    - name: Apply MCO template (iscsi)
+      ansible.builtin.shell: |
+        set -ex
+        export KUBECONFIG={{ kubeconfig }}
+        {{ oc_bin }} apply -f "{{ gpfsfolder }}/99-mco-iscsi-multipath-butaned.yaml"

--- a/templates/mco-iscsi-multipath.yaml
+++ b/templates/mco-iscsi-multipath.yaml
@@ -1,0 +1,126 @@
+variant: openshift
+version: 4.18.0
+metadata:
+  name: 99-worker-mpath-iscsi
+  labels:
+    machineconfiguration.openshift.io/role: worker
+storage:
+  files:
+    - path: /etc/multipath.conf
+      mode: 0420
+      overwrite: true
+      contents:
+        inline: |
+          defaults {
+              user_friendly_names yes
+          }
+          blacklist {
+              device {
+                  vendor NVME
+              }
+          }
+          devices {
+              device {
+                  vendor "LIO-ORG"
+                  product "*"
+                  path_grouping_policy multibus
+                  failback immediate
+                  rr_weight priorities
+                  rr_min_io 100
+                  path_checker tur
+              }
+          }
+
+    - path: /usr/local/sbin/iscsi-login
+      mode: 0755
+      overwrite: true
+      contents:
+        inline: |
+          #!/bin/bash
+          # Simulate multipath by using two different IPs
+          declare -a TARGET_IPS=("{{ iscsi_target_primary_ip }}" "{{ iscsi_target_secondary_ip }}")
+          TARGET_IQN={{iscsi_target_iqn}}
+          check_target() {
+          IP=$1
+          ACTIVE_SESSIONS=$(iscsiadm -m session 2>&1)
+          if [[ 0$(echo ${ACTIVE_SESSIONS} | grep -c -e "${IP}.*${TARGET_IQN}") -ge 01 ]]
+          then
+            echo "Target found"
+            return 0
+          else
+            echo "Target not found"
+            return 1
+          fi
+          }
+
+          main(){
+            for TARGET_IP in "${TARGET_IPS[@]}"; do
+              check_target ${TARGET_IP}
+              TARGET_FOUND=$?
+              if [[ 0${TARGET_FOUND} -eq 00 ]]
+              then
+                echo "iSCSI already configured for ${TARGET_IP}"
+                continue
+              else
+                echo "iSCSI not configured, configuring"
+                iscsiadm -m discovery -t st -p ${TARGET_IP}
+                sleep 3
+                iscsiadm --mode  node --target ${TARGET_IQN} --portal ${TARGET_IP} -l
+                sleep 3
+                check_target ${TARGET_IP}
+                TARGET_FOUND=$?
+                if [[ 0${TARGET_FOUND} -eq 00 ]]
+                then
+                  echo "iSCSI configured correctly"
+                  continue
+                else
+                  echo "Failed to configure iSCSI"
+                  exit 1
+                fi
+              fi
+            done
+          }
+          main
+          exit $?
+
+systemd:
+  units:
+    - name: iscsid.service
+      enabled: true
+    - name: iscsi.service
+      enabled: true
+    - name: multipathd.service
+      enabled: true
+    - name: custom-coreos-generate-iscsi-initiatorname.service
+      enabled: true
+      contents: |
+        [Unit]
+        Description=Custom CoreOS Generate iSCSI Initiator Name
+        Before=coreos-generate-iscsi-initiatorname.service
+        Before=iscsid.service
+
+        [Service]
+        Type=oneshot
+        ExecStart=/usr/bin/sh -c 'echo "InitiatorName=`hostname`" > /etc/iscsi/initiatorname.iscsi'
+        RemainAfterExit=yes
+
+        [Install]
+        WantedBy=multi-user.target
+    - name: "iscsi-login-target.service"
+      enabled: true
+      contents: |
+        [Unit]
+        Description=Logs into the iSCSI target if not already logged in
+        Before=kubelet.service
+        After=iscsi.service iscsid.service
+
+        [Service]
+        Type=oneshot
+        RemainAfterExit=no
+        User=root
+        ExecStart=/usr/local/sbin/iscsi-login
+
+        TimeoutSec=300
+
+        [Install]
+        WantedBy=multi-user.target


### PR DESCRIPTION
This allows us to use multipath with iscsi in our dev env

## Summary by Sourcery

Enable iSCSI multipath support in the development environment by automating the provisioning and cleanup of an AWS EC2 iSCSI target and configuring multipath on worker nodes through new playbooks, Makefile targets, and MCO templates.

New Features:
- Add Makefile targets 'iscsi' and 'iscsi-cleanup' to provision and teardown an AWS EC2 iSCSI target.
- Introduce Ansible playbooks to automate creation, configuration, and cleanup of an AWS EC2-based iSCSI target with EBS volumes.

Enhancements:
- Provide a Butane/MachineConfigOperator template to enable multipath and iSCSI login on cluster worker nodes.
- Include a custom iscsi-login script and systemd units to manage multi-path iSCSI sessions on boot.