### PR TITLE
Adapt to the new names

### DIFF
--- a/templates/fusionaccess.yaml
+++ b/templates/fusionaccess.yaml
@@ -4,6 +4,6 @@ metadata:
   name: fusionaccess-object
   namespace: "{{ operator_namespace }}"
 spec:
-  ibm_cnsa_version: {{ gpfs_cnsa_version }}
-  storagedevicediscovery:
+  storageScaleVersion: {{ gpfs_cnsa_version }}
+  storageDeviceDiscovery:
     create: true


### PR DESCRIPTION
## Summary by Sourcery

Update the fusionaccess CR template to align with the new storage field naming conventions in Kubernetes resources

Enhancements:
- Rename ibm_cnsa_version to storageScaleVersion
- Rename storagedevicediscovery to storageDeviceDiscovery