### PR TITLE
Stop using kernel-devel, we use KMM now

### DIFF
--- a/templates/mco.yaml
+++ b/templates/mco.yaml
@@ -5,8 +5,8 @@ metadata:
   labels:
     machineconfiguration.openshift.io/role: worker
 openshift:
-  extensions:
-    - kernel-devel
+  # extensions:
+  #   - kernel-devel
   kernel_arguments:
     - crashkernel=4096M
 storage:


### PR DESCRIPTION
## Summary by Sourcery

Chores:
- Remove the commented-out kernel-devel extension from the worker MachineConfig template in mco.yaml