### PR TITLE
Set default versions to GA

### DIFF
--- a/group_vars/all
+++ b/group_vars/all
@@ -35,7 +35,7 @@ butane_arch: >-
 # Default version to be used, run "make ocp-versions" to see which are the latest
 # ones and download them with "make ocp-clients"
 # ocp_version: "4.19.0-ec.5"
-ocp_version: "4.19.0-rc.3"
+ocp_version: "4.19.1"
 # For Dev-preview just use: "ocp-dev-preview", the rest of the URL segments remain the same.
 ocp_channel: "ocp"
 
@@ -67,7 +67,7 @@ gpfs_version: "v5.2.2.x"
 gpfs_volume_name: "gpfs-volume"
 gpfs_shared_lun: "/dev/nvme1n1"
 # Version installed when using the openshift-fusion-access operator
-gpfs_cnsa_version: "v5.2.3.1.dev3"
+gpfs_cnsa_version: "v5.2.3.1"
 gpfs_fs_name: "localfilesystem1"
 
 grafana_ns: "grafana-for-cnsa"


### PR DESCRIPTION
## Summary by Sourcery

Enhancements:
- Bump default version variables in group_vars/all to GA releases.