### PR TITLE
Noop the MCO steps

### DIFF
--- a/playbooks/install.yml
+++ b/playbooks/install.yml
@@ -112,7 +112,7 @@
 
     - name: Create gpfs folder
       tags:
-        - 1_ocp_install_mco
+        - 1_ocp_install
       ansible.builtin.file:
         path: "{{ gpfsfolder }}"
         state: directory
@@ -132,47 +132,47 @@
         {{ butane_bin }} "{{ gpfsfolder }}/mco.yaml" -o "{{ gpfsfolder }}/99-mco-butaned.yaml"
 
     # We apply the MCO template right away as it makes for less errors
-    - name: Apply MCO template
-      tags:
-        - 1_ocp_install_mco
-      ansible.builtin.shell: |
-        set -ex
-        export KUBECONFIG={{ kubeconfig }}
-        {{ oc_bin }} apply -f {{ gpfsfolder }}/99-mco-butaned.yaml
+    # - name: Apply MCO template
+    #   tags:
+    #     - 1_ocp_install_mco
+    #   ansible.builtin.shell: |
+    #     set -ex
+    #     export KUBECONFIG={{ kubeconfig }}
+    #     {{ oc_bin }} apply -f {{ gpfsfolder }}/99-mco-butaned.yaml
 
     # FIXME(bandini): Sleep here for a bit so we're sure it is started
     # later we should wait for the mcp's to go in updating status and then
     # wait for the finished condition
-    - name: Wait a bit for MCP to start
-      tags:
-        - 1_ocp_install_mco
-      ansible.builtin.pause:
-        minutes: 1
-
-    - name: Speed up MCO
-      tags:
-        - 1_ocp_install_mco
-      ansible.builtin.shell: |
-        set -ex
-        export KUBECONFIG={{ kubeconfig }}
-        {{ oc_bin }} patch mcp worker --type merge --patch '{"spec": {"maxUnavailable": 2}}'
-
-    - name: Wait for MCP to settle
-      tags:
-        - 1_ocp_install_mco
-      ansible.builtin.shell: |
-        set -ex
-        export KUBECONFIG={{ kubeconfig }}
-        if [ $({{ oc_bin }} get mcp/master -o jsonpath='{.status.readyMachineCount}') != $({{ oc_bin }} get mcp/master -o jsonpath='{.status.machineCount}') ]; then
-          exit 1
-        fi
-        if [ $({{ oc_bin }} get mcp/worker -o jsonpath='{.status.readyMachineCount}') != $({{ oc_bin }} get mcp/worker -o jsonpath='{.status.machineCount}') ]; then
-          exit 1
-        fi
-      retries: 40
-      delay: 90
-      register: mcp_ready
-      until: mcp_ready is not failed
+    # - name: Wait a bit for MCP to start
+    #   tags:
+    #     - 1_ocp_install_mco
+    #   ansible.builtin.pause:
+    #     minutes: 1
+    #
+    # - name: Speed up MCO
+    #   tags:
+    #     - 1_ocp_install_mco
+    #   ansible.builtin.shell: |
+    #     set -ex
+    #     export KUBECONFIG={{ kubeconfig }}
+    #     {{ oc_bin }} patch mcp worker --type merge --patch '{"spec": {"maxUnavailable": 2}}'
+    #
+    # - name: Wait for MCP to settle
+    #   tags:
+    #     - 1_ocp_install_mco
+    #   ansible.builtin.shell: |
+    #     set -ex
+    #     export KUBECONFIG={{ kubeconfig }}
+    #     if [ $({{ oc_bin }} get mcp/master -o jsonpath='{.status.readyMachineCount}') != $({{ oc_bin }} get mcp/master -o jsonpath='{.status.machineCount}') ]; then
+    #       exit 1
+    #     fi
+    #     if [ $({{ oc_bin }} get mcp/worker -o jsonpath='{.status.readyMachineCount}') != $({{ oc_bin }} get mcp/worker -o jsonpath='{.status.machineCount}') ]; then
+    #       exit 1
+    #     fi
+    #   retries: 40
+    #   delay: 90
+    #   register: mcp_ready
+    #   until: mcp_ready is not failed
 
     # See https://www.ibm.com/docs/en/scalecontainernative/5.2.2?topic=aws-red-hat-openshift-configuration#authorize-rosa-worker-security-group-to-allow-ibm-storage-scale-container-native-ports
     - name: Gather security group info for workers


### PR DESCRIPTION
They are never needed these day.

We still template them out in case one needs to enable kdump,
but that is really it

## Summary by Sourcery

Noop the Machine Config Operator steps in the install playbook by disabling their tasks while retaining template generation

Enhancements:
- Comment out all MCO application, patching, and waiting tasks in install.yml
- Change GPFS folder creation tag from 1_ocp_install_mco to 1_ocp_install