### PR TITLE
Switch to the cheaper nodes by default

### DIFF
--- a/vars/power90.yaml
+++ b/vars/power90.yaml
@@ -1,7 +1,7 @@
 power_ninety: true
 ebs_volume_size: 300
 ocp_cluster_name: gpfs-demo
-ocp_worker_type: m5.metal
+ocp_worker_type: c5n.metal
 ocp_master_type: m5.4xlarge
 ocp_az: eu-north-1a
 ocp_region: eu-north-1


### PR DESCRIPTION
## Summary by Sourcery

Enhancements:
- Change default OpenShift worker instance type from m5.metal to c5n.metal to reduce costs.