### PR TITLE
oadp support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -35,6 +35,10 @@ virt: ## Configures the virt bits (only for POWER90)
 	@if [ "$(POWER90)" = "false" ]; then echo "Error, virt is only for power90"; exit 1; fi
 	ansible-playbook -i hosts $(TAGS_STRING) $(EXTRA_ARGS) $(EXTRA_VARS) playbooks/virt.yml
 
+.PHONY: oadp
+oadp: ## Configures oadp
+	ansible-playbook -i hosts $(TAGS_STRING) $(EXTRA_ARGS) $(EXTRA_VARS) playbooks/oadp.yml
+
 .PHONY: iib
 iib: ## Install an iib on an OCP cluster on AWS
 	ansible-playbook -i hosts $(TAGS_STRING) $(EXTRA_VARS) playbooks/iib.yml

--- a/group_vars/all
+++ b/group_vars/all
@@ -105,6 +105,11 @@ dbperf_tar: "https://acksyn.org/stuff/hammerdb-tpcc-wrapper-scripts-kit.tar"
 virt_test_ns: "virt-test"
 virt_vm_name: "centos-db"
 
+oadp_s3_owner: "s3-oadp-{{ ocp_cluster_name }}"
+oadp_s3_policy: "{{ oadp_s3_bucket }}-owner-policy"
+oadp_s3_bucket: "oadp-s3-{{ ocp_cluster_name }}"
+oadp_s3_url: "https://{{ oadp_s3_bucket }}.s3.{{ ocp_region }}.amazonaws.com"
+
 iscsi_target_iqn: iqn.2024-02.com.example
 iscsi_target_primary_ip: 10.0.100.100
 iscsi_target_secondary_ip: 10.0.100.101

--- a/group_vars/all
+++ b/group_vars/all
@@ -101,7 +101,9 @@ ssh_pubkey: "{{ lookup('file', '~/.ssh/id_rsa.pub' | expanduser) }}"
 power_ninety: false
 vmpass: "{{ lookup('file', '~/.vmpass' | expanduser) }}"
 dbperf_tar: "https://acksyn.org/stuff/hammerdb-tpcc-wrapper-scripts-kit.tar"
+
 virt_test_ns: "virt-test"
+virt_vm_name: "centos-db"
 
 iscsi_target_iqn: iqn.2024-02.com.example
 iscsi_target_primary_ip: 10.0.100.100

--- a/group_vars/all
+++ b/group_vars/all
@@ -112,6 +112,7 @@ oadp_s3_policy: "{{ oadp_s3_bucket }}-owner-policy"
 oadp_s3_bucket: "oadp-s3-{{ ocp_cluster_name }}"
 oadp_s3_url: "https://{{ oadp_s3_bucket }}.s3.{{ ocp_region }}.amazonaws.com"
 oadp_s3_secret: "aws-s3-secret"
+oadp_backup_name: "backup1"
 
 iscsi_target_iqn: iqn.2024-02.com.example
 iscsi_target_primary_ip: 10.0.100.100

--- a/group_vars/all
+++ b/group_vars/all
@@ -105,10 +105,13 @@ dbperf_tar: "https://acksyn.org/stuff/hammerdb-tpcc-wrapper-scripts-kit.tar"
 virt_test_ns: "virt-test"
 virt_vm_name: "centos-db"
 
+oadp_ns: "openshift-adp"
+oadp_dpa_name: "dpa-s3"
 oadp_s3_owner: "s3-oadp-{{ ocp_cluster_name }}"
 oadp_s3_policy: "{{ oadp_s3_bucket }}-owner-policy"
 oadp_s3_bucket: "oadp-s3-{{ ocp_cluster_name }}"
 oadp_s3_url: "https://{{ oadp_s3_bucket }}.s3.{{ ocp_region }}.amazonaws.com"
+oadp_s3_secret: "aws-s3-secret"
 
 iscsi_target_iqn: iqn.2024-02.com.example
 iscsi_target_primary_ip: 10.0.100.100

--- a/playbooks/destroy.yml
+++ b/playbooks/destroy.yml
@@ -133,11 +133,18 @@
         - oadp
       amazon.aws.iam_access_key:
         user_name: "{{ oadp_s3_owner }}"
-        access_key_id: "{{ item.access_key_id }}"
+        id: "{{ item.access_key_id }}"
         state: absent
         profile: "{{ aws_profile }}"
       loop: "{{ key_info.access_keys }}"
       failed_when: false
+      register: key_delete_result
+
+    - name: Debug key delete
+      tags:
+        - oadp
+      ansible.builtin.debug:
+        msg: "{{ key_delete_result }}"
 
     - name: Delete the IAM s3 user with policy
       tags:

--- a/playbooks/destroy.yml
+++ b/playbooks/destroy.yml
@@ -65,3 +65,98 @@
         state: absent
       loop: "{{ volume_info_two.volumes }}"
       when: power_ninety | bool and volume_info_two.volumes | length > 0
+
+    - name: Delete all objects in the S3 bucket
+      tags:
+        - oadp
+      amazon.aws.aws_s3:
+        bucket: "{{ oadp_s3_bucket }}"
+        mode: delete
+        region: "{{ ocp_region }}"
+        recurse: yes  # delete all objects
+        profile: "{{ aws_profile }}"
+      failed_when: false
+
+    - name: Destroy oadp s3 bucket
+      tags:
+        - oadp
+      amazon.aws.s3_bucket:
+        name: "{{ oadp_s3_bucket }}"
+        state: absent
+        region: "{{ ocp_region }}"
+        profile: "{{ aws_profile }}"
+        recurse: true
+      failed_when: false
+
+    - name: Get IAM policy ARN by name
+      tags:
+        - oadp
+      amazon.aws.iam_policy_info:
+        iam_type: user
+        iam_name: "{{ oadp_s3_owner }}"
+        profile: "{{ aws_profile }}"
+      register: policy_info
+
+    - name: Print ARN policies for user
+      tags:
+        - oadp
+      ansible.builtin.debug:
+        msg: "{{ policy_info }}"
+
+    - name: Set fact for the policy ARN
+      tags:
+        - oadp
+      set_fact:
+        my_policy_arn: "{{ item.arn }}"
+      loop: "{{ policy_info.policies }}"
+      when: item.policy_name == "{{ oadp_s3_bucket }}-owner-policy"
+
+    - name: Delete the IAM policy
+      tags:
+        - oadp
+      amazon.aws.iam_policy:
+        name: "{{ oadp_s3_policy }}"
+        state: absent
+        profile: "{{ aws_profile }}"
+      failed_when: false
+
+    - name: List IAM user's access keys
+      tags:
+        - oadp
+      amazon.aws.iam_access_key_info:
+        user_name: "{{ oadp_s3_owner }}"
+        profile: "{{ aws_profile }}"
+      register: key_info        
+
+    - name: Delete IAM access key
+      tags:
+        - oadp
+      amazon.aws.iam_access_key:
+        user_name: "{{ oadp_s3_owner }}"
+        access_key_id: "{{ item.access_key_id }}"
+        state: absent
+        profile: "{{ aws_profile }}"
+      loop: "{{ key_info.access_keys }}"
+      failed_when: false
+
+    - name: Delete the IAM s3 user with policy
+      tags:
+        - oadp
+      amazon.aws.iam_user:
+        name: s3-bucket-owner
+        state: absent      
+        profile: "{{ aws_profile }}"
+        managed_policies:
+          - "{{ my_policy_arn }}"
+      failed_when: false
+      when: my_policy_arn is defined
+
+    - name: Delete the IAM s3 user
+      tags:
+        - oadp
+      amazon.aws.iam_user:
+        name: s3-bucket-owner
+        state: absent      
+        profile: "{{ aws_profile }}"
+      failed_when: false
+      when: my_policy_arn is not defined

--- a/playbooks/oadp.yml
+++ b/playbooks/oadp.yml
@@ -126,8 +126,8 @@
           stringData:
             cloud: |
               [default]
-              aws_access_key_id = "{{ s3_owner_keys.access_key_id }}"
-              aws_secret_access_key = "{{ s3_owner_keys.secret_access_key }}"
+              aws_access_key_id = {{ s3_owner_keys.access_key_id }}
+              aws_secret_access_key = {{ s3_owner_keys.secret_access_key }}
           type: Opaque
 
     - name: Create DataProtectionApplication (DPA)
@@ -149,7 +149,8 @@
                   - openshift
                   - kubevirt
             backupLocations:
-              - velero:
+              - name: s3-backup
+                velero:
                   provider: aws
                   default: true
                   objectStorage:
@@ -157,8 +158,7 @@
                     prefix: velero
                   config:
                     region: "{{ ocp_region }}"
-                    s3ForcePathStyle: "true"
-                    s3Url: "{{ oadp_s3_url }}"
+                    # s3Url: "{{ oadp_s3_url }}"
                   credential:
                     name: "{{ oadp_s3_secret }}"
                     key: cloud
@@ -175,3 +175,40 @@
       retries: 30
       delay: 10
       until: dpa_status.resources[0].status.conditions | selectattr('type', 'equalto', 'Reconciled') | selectattr('status', 'equalto', 'True') | list | length > 0
+
+    - name: Create VM snapshot using OADP (Velero Backup CR)
+      kubernetes.core.k8s:
+        state: present
+        definition:
+          apiVersion: velero.io/v1
+          kind: Backup
+          metadata:
+            name: "{{ oadp_backup_name }}"
+            namespace: "{{ oadp_ns }}"
+          spec:
+            includedNamespaces:
+              - "{{ virt_test_ns }}"
+            includedResources:
+              - virtualmachines.kubevirt.io
+              - persistentvolumeclaims
+              - pods
+            labelSelector:
+              matchLabels:
+                app: "{{ virt_vm_name }}"
+            storageLocation: s3-backup
+            ttl: 720h0m0s
+
+    - name: Wait for backup to complete
+      kubernetes.core.k8s_info:
+        api_version: velero.io/v1
+        kind: Backup
+        namespace: "{{ oadp_ns }}"
+        name: "{{ oadp_backup_name }}"
+      register: backup_status
+      retries: 30
+      delay: 20
+      until: backup_status.resources[0].status.phase == 'Completed'
+
+    - name: Confirm backup success
+      debug:
+        msg: "Backup '{{ backup_name }}' completed and uploaded to S3 bucket '{{ oadp_s3_bucket }}'."

--- a/playbooks/oadp.yml
+++ b/playbooks/oadp.yml
@@ -1,0 +1,38 @@
+---
+- name: Playbook to set up the virt demo bits
+  hosts: localhost
+  gather_facts: false
+  become: false
+  vars_files:
+    # Use this to override stuff that won't be committed to git
+    - ../overrides.yml
+  tasks:
+    - name: Print AWS infos
+      ansible.builtin.debug:
+        msg: "Region: {{ ocp_region }} - Cluster: {{ ocp_cluster_name }}.{{ ocp_domain }} - Workers [{{ ocp_worker_count }}]: {{ ocp_worker_type }}"
+
+    - name: Check if cluster has gpfs installed correctly
+      ansible.builtin.shell: |
+        set -ex
+        export KUBECONFIG={{ kubeconfig }}
+        oc get filesystems -A
+
+    - name: Template virt subscription files
+      ansible.builtin.template:
+        src: ../templates/{{ item }}
+        dest: "{{ gpfsfolder }}/{{ item }}"
+        mode: "0644"
+      loop:
+        - oadp-subscription.yaml
+
+    - name: Apply oadp subscription
+      ansible.builtin.shell: |
+        set -e
+        export KUBECONFIG="{{ kubeconfig }}"
+        {{ oc_bin }} apply -f "{{ gpfsfolder }}/{{ item }}"
+      register: virt_apply
+      until: virt_apply is not failed
+      retries: 20
+      delay: 10
+      loop:
+        - oadp-subscription.yaml

--- a/playbooks/oadp.yml
+++ b/playbooks/oadp.yml
@@ -17,7 +17,9 @@
         export KUBECONFIG={{ kubeconfig }}
         oc get filesystems -A
 
-    - name: Template virt subscription files
+    - name: Template oadp subscription files
+      tags:
+        - oadp
       ansible.builtin.template:
         src: ../templates/{{ item }}
         dest: "{{ gpfsfolder }}/{{ item }}"
@@ -26,6 +28,8 @@
         - oadp-subscription.yaml
 
     - name: Apply oadp subscription
+      tags:
+        - oadp
       ansible.builtin.shell: |
         set -e
         export KUBECONFIG="{{ kubeconfig }}"
@@ -36,3 +40,75 @@
       delay: 10
       loop:
         - oadp-subscription.yaml
+
+    - name: Create S3 bucket
+      tags:
+        - oadp
+      amazon.aws.s3_bucket:
+        name: "{{ oadp_s3_bucket }}"
+        state: present
+        region: "{{ ocp_region }}"
+        profile: "{{ aws_profile }}"
+      register: s3_create_result
+
+    - name: Create IAM policy granting full access to a specific bucket
+      tags:
+        - oadp
+      amazon.aws.iam_managed_policy:
+        name: "{{ oadp_s3_policy }}"
+        profile: "{{ aws_profile }}"
+        state: present
+        policy: |
+          {
+            "Version": "2012-10-17",
+            "Statement": [
+              {
+                "Effect": "Allow",
+                "Action": "s3:*",
+                "Resource": [
+                  "arn:aws:s3:::{{ oadp_s3_bucket }}",
+                  "arn:aws:s3:::{{ oadp_s3_bucket }}/*"
+                ]
+              }
+            ]
+          }
+      register: s3_policy
+
+    - name: Print S3 info
+      tags:
+        - oadp
+      ansible.builtin.debug:
+        msg: "{{ s3_create_result }}"
+
+    - name: Print s3 bucket url
+      tags:
+        - oadp
+      ansible.builtin.debug:
+        msg: "{{ oadp_s3_url }}"
+
+    - name: Create s3 bucket owner
+      tags:
+        - oadp
+      amazon.aws.iam_user:
+        name: "{{ oadp_s3_owner }}"
+        state: present
+        profile: "{{ aws_profile }}"
+        managed_policies:
+          - "{{ s3_policy.policy.arn }}"
+
+    - name: Create access key for user
+      tags:
+        - oadp
+      amazon.aws.iam_access_key:
+        user_name: "{{ oadp_s3_owner }}"
+        state: present
+        profile: "{{ aws_profile }}"
+      register: s3_owner_keys
+
+    - name: Write these keys to file just in case
+      tags:
+        - oadp
+      ansible.builtin.copy:
+        dest: "{{ gpfsfolder }}/oadp-s3-creds.txt"
+        content: "{{ s3_owner_keys }}"
+

--- a/playbooks/oadp.yml
+++ b/playbooks/oadp.yml
@@ -116,6 +116,7 @@
       tags:
         - oadp2
       kubernetes.core.k8s:
+        kubeconfig: "{{ kubeconfig }}"
         state: present
         definition:
           apiVersion: v1
@@ -134,6 +135,7 @@
       tags:
         - oadp2
       kubernetes.core.k8s:
+        kubeconfig: "{{ kubeconfig }}"
         state: present
         definition:
           apiVersion: oadp.openshift.io/v1alpha1
@@ -167,6 +169,7 @@
       tags:
         - oadp2
       kubernetes.core.k8s_info:
+        kubeconfig: "{{ kubeconfig }}"
         api_version: oadp.openshift.io/v1alpha1
         kind: DataProtectionApplication
         namespace: "{{ oadp_ns }}"
@@ -178,6 +181,7 @@
 
     - name: Create VM snapshot using OADP (Velero Backup CR)
       kubernetes.core.k8s:
+        kubeconfig: "{{ kubeconfig }}"
         state: present
         definition:
           apiVersion: velero.io/v1
@@ -200,6 +204,7 @@
 
     - name: Wait for backup to complete
       kubernetes.core.k8s_info:
+        kubeconfig: "{{ kubeconfig }}"
         api_version: velero.io/v1
         kind: Backup
         namespace: "{{ oadp_ns }}"
@@ -207,8 +212,8 @@
       register: backup_status
       retries: 30
       delay: 20
-      until: backup_status.resources[0].status.phase == 'Completed'
+      until: (backup_status.resources | default([]) | length > 0) and backup_status.resources[0].status.phase == 'Completed'
 
     - name: Confirm backup success
       debug:
-        msg: "Backup '{{ backup_name }}' completed and uploaded to S3 bucket '{{ oadp_s3_bucket }}'."
+        msg: "Backup '{{ oadp_backup_name }}' completed and uploaded to S3 bucket '{{ oadp_s3_bucket }}'."

--- a/playbooks/oadp.yml
+++ b/playbooks/oadp.yml
@@ -112,3 +112,66 @@
         dest: "{{ gpfsfolder }}/oadp-s3-creds.txt"
         content: "{{ s3_owner_keys }}"
 
+    - name: Create Secret for AWS credentials (if not already created)
+      tags:
+        - oadp2
+      kubernetes.core.k8s:
+        state: present
+        definition:
+          apiVersion: v1
+          kind: Secret
+          metadata:
+            name: "{{ oadp_s3_secret }}"
+            namespace: "{{ oadp_ns }}"
+          stringData:
+            cloud: |
+              [default]
+              aws_access_key_id = "{{ s3_owner_keys.access_key_id }}"
+              aws_secret_access_key = "{{ s3_owner_keys.secret_access_key }}"
+          type: Opaque
+
+    - name: Create DataProtectionApplication (DPA)
+      tags:
+        - oadp2
+      kubernetes.core.k8s:
+        state: present
+        definition:
+          apiVersion: oadp.openshift.io/v1alpha1
+          kind: DataProtectionApplication
+          metadata:
+            name: "{{ oadp_dpa_name }}"
+            namespace: "{{ oadp_ns }}"
+          spec:
+            configuration:
+              velero:
+                defaultPlugins:
+                  - aws
+                  - openshift
+                  - kubevirt
+            backupLocations:
+              - velero:
+                  provider: aws
+                  default: true
+                  objectStorage:
+                    bucket: "{{ oadp_s3_bucket }}"
+                    prefix: velero
+                  config:
+                    region: "{{ ocp_region }}"
+                    s3ForcePathStyle: "true"
+                    s3Url: "{{ oadp_s3_url }}"
+                  credential:
+                    name: "{{ oadp_s3_secret }}"
+                    key: cloud
+
+    - name: Wait for DPA to be ready
+      tags:
+        - oadp2
+      kubernetes.core.k8s_info:
+        api_version: oadp.openshift.io/v1alpha1
+        kind: DataProtectionApplication
+        namespace: "{{ oadp_ns }}"
+        name: "{{ oadp_dpa_name }}"
+      register: dpa_status
+      retries: 30
+      delay: 10
+      until: dpa_status.resources[0].status.conditions | selectattr('type', 'equalto', 'Reconciled') | selectattr('status', 'equalto', 'True') | list | length > 0

--- a/playbooks/virt.yml
+++ b/playbooks/virt.yml
@@ -80,3 +80,25 @@
         - virt-ssh-secret.yaml
         - virt-vm-db-service.yaml
         - virt-vm-cloudinit.yaml
+
+    - name: Create VM
+      ansible.builtin.shell: |
+        set -e
+        export KUBECONFIG="{{ kubeconfig }}"
+        {{ oc_bin }} apply -f "{{ gpfsfolder }}/{{ item }}"
+      register: virt_apply
+      until: virt_apply is not failed
+      retries: 20
+      delay: 10
+      loop:
+        - virt-vm-db.yaml
+
+    - name: Test ssh access to VM
+      ansible.builtin.shell: |
+        set -ex
+        export KUBECONFIG="{{ fullclusterfolder }}/auth/kubeconfig"
+        {{ virtctl_bin }} ssh --namespace {{ virt_test_ns }} -t="-o StrictHostKeyChecking=no" -t="-o UserKnownHostsFile=/dev/null" -i /home/michele/.ssh/id_ansible root@centos-db -c "sudo sh -c \"touch /root/iwashere\""
+      register: vm_ssh
+      until: vm_ssh is not failed
+      retries: 5
+      delay: 30

--- a/playbooks/virt.yml
+++ b/playbooks/virt.yml
@@ -99,7 +99,7 @@
       ansible.builtin.shell: |
         set -ex -o pipefail
         export KUBECONFIG="{{ kubeconfig }}"
-        {{ oc_bin }} get vmi -n {{ virt_test_ns }} centos-db -o jsonpath='{.status.phase}' | grep Running
+        {{ oc_bin }} get vmi -n {{ virt_test_ns }} {{ virt_vm_name }} -o jsonpath='{.status.phase}' | grep Running
       register: vm_up
       until: vm_up is not failed
       retries: 5
@@ -111,7 +111,7 @@
       ansible.builtin.shell: |
         set -ex
         export KUBECONFIG="{{ kubeconfig }}"
-        {{ virtctl_bin }} ssh --namespace {{ virt_test_ns }} -t="-o StrictHostKeyChecking=no" -t="-o UserKnownHostsFile=/dev/null" fedora@centos-db -c "sudo sh -c \"touch /root/iwashere\""
+        {{ virtctl_bin }} ssh --namespace {{ virt_test_ns }} -t="-o StrictHostKeyChecking=no" -t="-o UserKnownHostsFile=/dev/null" fedora@{{ virt_vm_name }} -c "sudo sh -c \"touch /root/iwashere\""
       register: vm_ssh
       until: vm_ssh is not failed
       retries: 5

--- a/playbooks/virt.yml
+++ b/playbooks/virt.yml
@@ -93,11 +93,25 @@
       loop:
         - virt-vm-db.yaml
 
+    - name: Wait for VM to be up
+      tags:
+        - ops
+      ansible.builtin.shell: |
+        set -ex -o pipefail
+        export KUBECONFIG="{{ kubeconfig }}"
+        {{ oc_bin }} get vmi -n {{ virt_test_ns }} centos-db -o jsonpath='{.status.phase}' | grep Running
+      register: vm_up
+      until: vm_up is not failed
+      retries: 5
+      delay: 30
+
     - name: Test ssh access to VM
+      tags:
+        - ops
       ansible.builtin.shell: |
         set -ex
-        export KUBECONFIG="{{ fullclusterfolder }}/auth/kubeconfig"
-        {{ virtctl_bin }} ssh --namespace {{ virt_test_ns }} -t="-o StrictHostKeyChecking=no" -t="-o UserKnownHostsFile=/dev/null" -i /home/michele/.ssh/id_ansible root@centos-db -c "sudo sh -c \"touch /root/iwashere\""
+        export KUBECONFIG="{{ kubeconfig }}"
+        {{ virtctl_bin }} ssh --namespace {{ virt_test_ns }} -t="-o StrictHostKeyChecking=no" -t="-o UserKnownHostsFile=/dev/null" fedora@centos-db -c "sudo sh -c \"touch /root/iwashere\""
       register: vm_ssh
       until: vm_ssh is not failed
       retries: 5

--- a/templates/oadp-subscription.yaml
+++ b/templates/oadp-subscription.yaml
@@ -11,7 +11,6 @@ metadata:
   name: redhat-oadp-operator
   namespace: "{{ oadp_ns }}"
 spec:
-spec:
   channel: stable
   installPlanApproval: Automatic
   name: redhat-oadp-operator

--- a/templates/oadp-subscription.yaml
+++ b/templates/oadp-subscription.yaml
@@ -1,0 +1,30 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: openshift-adp
+spec:
+---
+apiVersion: operators.coreos.com/v1alpha1
+kind: Subscription
+metadata:
+  name: redhat-oadp-operator
+  namespace: openshift-adp
+spec:
+spec:
+  channel: stable
+  installPlanApproval: Automatic
+  name: redhat-oadp-operator
+  source: redhat-operators
+  sourceNamespace: openshift-marketplace
+---
+apiVersion: operators.coreos.com/v1
+kind: OperatorGroup
+metadata:
+  name: openshift-adp-operator
+  namespace: openshift-adp
+spec:
+  targetNamespaces:
+    - openshift-adp
+  upgradeStrategy: Default  
+

--- a/templates/oadp-subscription.yaml
+++ b/templates/oadp-subscription.yaml
@@ -2,14 +2,14 @@
 apiVersion: v1
 kind: Namespace
 metadata:
-  name: openshift-adp
+  name: "{{ oadp_ns }}"
 spec:
 ---
 apiVersion: operators.coreos.com/v1alpha1
 kind: Subscription
 metadata:
   name: redhat-oadp-operator
-  namespace: openshift-adp
+  namespace: "{{ oadp_ns }}"
 spec:
 spec:
   channel: stable
@@ -22,9 +22,8 @@ apiVersion: operators.coreos.com/v1
 kind: OperatorGroup
 metadata:
   name: openshift-adp-operator
-  namespace: openshift-adp
+  namespace: "{{ oadp_ns }}"
 spec:
   targetNamespaces:
-    - openshift-adp
+    - "{{ oadp_ns }}"
   upgradeStrategy: Default  
-

--- a/templates/virt-vm-cloudinit.yaml
+++ b/templates/virt-vm-cloudinit.yaml
@@ -31,6 +31,8 @@ stringData:
     - |
       #!/bin/bash
       set -x
+      # for now we skip this init entirely
+      exit 0
       MAX_RETRIES=5
       RETRY_INTERVAL=10  # seconds
       URL="{{ dbperf_tar }}"

--- a/templates/virt-vm-db-service.yaml
+++ b/templates/virt-vm-db-service.yaml
@@ -9,4 +9,4 @@ spec:
       port: 3306
       targetPort: 3306
   selector:
-    app: centos-db
+    app: "{{ virt_vm_name }}"

--- a/templates/virt-vm-db.yaml
+++ b/templates/virt-vm-db.yaml
@@ -1,12 +1,12 @@
 apiVersion: kubevirt.io/v1
 kind: VirtualMachine
 metadata:
-  name: centos-db
+  name: "{{ virt_vm_name }}"
   namespace: "{{ virt_test_ns }}"
 spec:
   dataVolumeTemplates:
     - metadata:
-        name: centos-db-volume
+        name: "{{ virt_vm_name }}-volume"
         # Works around OCPNAS-60 for now
         annotations:
           cdi.kubevirt.io/cloneType: copy
@@ -31,7 +31,7 @@ spec:
     metadata:
       labels:
         network.kubevirt.io/headlessService: headless
-        app: centos-db
+        app: "{{ virt_vm_name }}"
     spec:
       accessCredentials:
         - sshPublicKey:
@@ -56,7 +56,7 @@ spec:
       subdomain: headless
       volumes:
         - dataVolume:
-            name: centos-db-volume
+            name: "{{ virt_vm_name }}-volume"
           name: rootdisk
         - name: cloudinitdisk
           cloudInitNoCloud:


### PR DESCRIPTION
- **Add some OADP support and also actually spwan the vm out of the box**
- **Fix ssh test and wait for vm to be up**
- **Add variable for vm name**
- **Add steps to create and destroy s3 bucket for oadp**
- **Fix key destroy**
- **Deploy a DPA in the openshift-adp namespace**
- **More work**
- **Fixes**

## Summary by Sourcery

Configure OADP backup workflows end-to-end and strengthen VM lifecycle management by spawning VMs with configurable names, waiting for readiness, validating SSH access, and fully cleaning up OADP resources.

New Features:
- Add playbook to install and configure OADP operator including subscription, S3 bucket, IAM user, and DataProtectionApplication deployment
- Implement VM provisioning tasks in virt playbook to apply VM manifests, wait for the VM to be Running, and verify SSH connectivity
- Introduce Velero backup via OADP by creating a Backup CR and polling for completion

Bug Fixes:
- Fix SSH test by retrying until the VM reaches Running state
- Ensure proper teardown of IAM policies and access keys during OADP cleanup

Enhancements:
- Parameterize VM resources using virt_vm_name and update templates accordingly
- Add Makefile oadp target for streamlined OADP playbook execution
- Skip cloud-init initialization step in VM template to prevent unnecessary delays
- Extend destroy playbook to clean up OADP resources including S3 bucket, IAM policies, access keys, and user