### PR TITLE
Complete oadp support

### DIFF
--- a/playbooks/oadp.yml
+++ b/playbooks/oadp.yml
@@ -145,6 +145,9 @@
             namespace: "{{ oadp_ns }}"
           spec:
             configuration:
+              nodeAgent:
+                enable: true
+                uploaderType: kopia
               velero:
                 defaultPlugins:
                   - csi

--- a/playbooks/oadp.yml
+++ b/playbooks/oadp.yml
@@ -212,12 +212,14 @@
             name: "{{ oadp_backup_name }}"
             namespace: "{{ oadp_ns }}"
           spec:
+            snapshotMoveData: true
             includedNamespaces:
               - "{{ virt_test_ns }}"
-            includedResources:
-              - virtualmachines.kubevirt.io
-              - persistentvolumeclaims
-              - pods
+            # includedResources:
+            #   - virtualmachines.kubevirt.io
+            #   - virtualmachineinstance.kubevirt.io
+            #   - persistentvolumeclaims
+            #   - pods
             labelSelector:
               matchLabels:
                 app: "{{ virt_vm_name }}"

--- a/playbooks/oadp.yml
+++ b/playbooks/oadp.yml
@@ -147,6 +147,7 @@
             configuration:
               velero:
                 defaultPlugins:
+                  - csi
                   - aws
                   - openshift
                   - kubevirt

--- a/playbooks/oadp.yml
+++ b/playbooks/oadp.yml
@@ -149,6 +149,7 @@
                 enable: true
                 uploaderType: kopia
               velero:
+                logLevel: debug
                 defaultPlugins:
                   - csi
                   - aws


### PR DESCRIPTION
- **Enable csi plugin in dpa**
- **Use nodeagent (oadp 1.5)**
- **Add debug loglevel**
- **Working state**

## Summary by Sourcery

Configure OADP deployment for full support by enabling nodeAgent and CSI plugin, activating debug logging, and enabling snapshot data movement

New Features:
- Enable nodeAgent with Kopia uploader in OADP configuration
- Enable CSI plugin in Velero default plugins
- Activate debug log level for Velero
- Enable snapshotMoveData for backups

Enhancements:
- Remove static includedResources as comments to allow dynamic resource handling