### PR TITLE
Add user info as a tag to resources

### DIFF
--- a/playbooks/install.yml
+++ b/playbooks/install.yml
@@ -13,6 +13,25 @@
       ansible.builtin.debug:
         msg: "Region: {{ ocp_region }} - Cluster: {{ ocp_cluster_name }}.{{ ocp_domain }} - Workers [{{ ocp_worker_count }}]: {{ ocp_worker_type }} - AWS Profile: {{ aws_profile }}"
 
+    - name: Get AWS caller identity for Owner tag
+      tags:
+        - 1_ocp_install
+      amazon.aws.aws_caller_info:
+        profile: "{{ aws_profile }}"
+      register: aws_caller_info
+
+    - name: Set OCP owner from AWS user
+      tags:
+        - 1_ocp_install
+      ansible.builtin.set_fact:
+        ocp_owner: "{{ aws_caller_info.arn.split('/')[-1] | default(ansible_env.USER) | default(ansible_user_id) | default('unknown') }}"
+
+    - name: Print Owner info
+      tags:
+        - 1_ocp_install
+      ansible.builtin.debug:
+        msg: "OCP instances will be tagged with Owner: {{ ocp_owner }}"
+
     - name: Verify htpasswd exists
       ansible.builtin.command:
         cmd: which htpasswd

--- a/templates/full-cluster-install-config.j2.yaml
+++ b/templates/full-cluster-install-config.j2.yaml
@@ -34,6 +34,8 @@ networking:
 platform:
   aws:
     region: {{ ocp_region }}
+    userTags:
+      Owner: "{{ ocp_owner }}"
 pullSecret: '{{ pullsecret | regex_replace('\'', '"') }}'
 sshKey: |
   {{ ssh_pubkey | regex_replace('"', '') }}


### PR DESCRIPTION
## Summary by Sourcery

Fetch the AWS caller identity during installation to set an OCP owner and tag AWS resources accordingly.

New Features:
- Retrieve AWS caller identity and derive ocp_owner in the install playbook
- Add an Owner userTag under the AWS platform in the full-cluster-install template

Enhancements:
- Fallback to environment user variables or "unknown" if AWS ARN parsing fails