### PR TITLE
Fix print versions

### DIFF
--- a/playbooks/print-ocp-versions.yml
+++ b/playbooks/print-ocp-versions.yml
@@ -6,8 +6,7 @@
     ocp_url: https://mirror.openshift.com/pub/openshift-v4/x86_64/clients/ocp/
     ocp_tmp_file: /tmp/ocp-versions.html
     major_versions:
-      - "4.17"
-      - "4.18"
+      - "4.19"
   tasks:
     - name: Fetch URL
       ansible.builtin.get_url:
@@ -21,7 +20,7 @@
         grep -E '<a href="[[:digit:]]+.[[:digit:]]+.[[:digit:]]+.*">' "{{ ocp_tmp_file }}" | \
           sed -e 's/<a href="//' | sed -e 's/\/">//' | awk '{$1=$1};1' | sort --version-sort | \
           grep -w -e "^{{ item }}" | tail -n1
-        rm "{{ ocp_tmp_file }}"
+        rm -f "{{ ocp_tmp_file }}"
       register: versions_output
       with_items: "{{ major_versions }}"
 


### PR DESCRIPTION
## Summary by Sourcery

Update the print-ocp-versions playbook to target OCP 4.19 and handle temporary file cleanup more robustly

Bug Fixes:
- Add force flag to rm command to avoid errors when the temporary file is missing

Enhancements:
- Bump supported OCP major version to 4.19