### PR TITLE
Fix error when destroying cluster

### DIFF
--- a/playbooks/destroy.yml
+++ b/playbooks/destroy.yml
@@ -98,7 +98,7 @@
       set_fact:
         my_policy_arn: "{{ item.arn }}"
       loop: "{{ policy_info.policies }}"
-      when: item.policy_name == "{{ oadp_s3_bucket }}-owner-policy"
+      when: item.policy_name | default('') == "{{ oadp_s3_bucket }}-owner-policy"
 
     - name: Delete the IAM policy
       tags:


### PR DESCRIPTION
## Summary by Sourcery

Bug Fixes:
- Add default('') filter to the IAM policy deletion conditional to prevent undefined policy_name errors