### PR TITLE
Miscellaneous small improvements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ overrides.yml
 .venv
 .tmp
 infra
+.vscode/

--- a/Makefile
+++ b/Makefile
@@ -80,6 +80,10 @@ iscsi-cleanup: ## Removes iscsi ec2 resources
 list-tags: ## Lists all tags in the install playbook
 	ansible-playbook --list-tags playbooks/install.yml
 
+.PHONY: ansible-deps
+ansible-deps: ## Install Ansible dependencies
+	ansible-galaxy collection install -r requirements.yml
+
 ##@ CI / Linter tasks
 .PHONY: lint
 lint: ## Run ansible-lint on the codebase

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ Change it by uncommenting and tweaking at least the following lines:
 4. Make sure you read `group_vars/all` and have all the files with the secret material done
 5. Run `make ocp-clients`. This will download the needed oc + openshift-install version
    in your home folder under `~/aws-gpfs-playground/<ocp_version>`
-6. Then run either `make install` for the openshift-fusion-access operator install or `make classic-install` to use the traditional method via the steps outlined by Mario in his doc.
+6. Run `make install` to install the openshift-fusion-access operator
 
 
 ## Deletion

--- a/playbooks/install.yml
+++ b/playbooks/install.yml
@@ -267,6 +267,7 @@
         iops: "{{ ebs_iops }}"
         tags:
           Name: "{{ gpfs_volume_name }}"
+          Owner: "{{ ocp_owner }}"
       register: ebs_volume
 
     - name: Attach EBS volume to workers
@@ -294,6 +295,7 @@
         iops: "{{ ebs_iops_two }}"
         tags:
           Name: "{{ gpfs_volume_name_two }}"
+          Owner: "{{ ocp_owner }}"
       register: ebs_volume_two
       when: power_ninety | bool
 

--- a/playbooks/print-ocp-versions.yml
+++ b/playbooks/print-ocp-versions.yml
@@ -2,6 +2,7 @@
 - name: Fetch OCP versions
   hosts: localhost
   gather_facts: false
+  become: false
   vars:
     ocp_url: https://mirror.openshift.com/pub/openshift-v4/x86_64/clients/ocp/
     ocp_tmp_file: /tmp/ocp-versions.html
@@ -20,9 +21,11 @@
         grep -E '<a href="[[:digit:]]+.[[:digit:]]+.[[:digit:]]+.*">' "{{ ocp_tmp_file }}" | \
           sed -e 's/<a href="//' | sed -e 's/\/">//' | awk '{$1=$1};1' | sort --version-sort | \
           grep -w -e "^{{ item }}" | tail -n1
-        rm -f "{{ ocp_tmp_file }}"
       register: versions_output
       with_items: "{{ major_versions }}"
+
+    - name: Cleanup
+      ansible.builtin.shell: rm -f "{{ ocp_tmp_file }}"
 
     - name: Debug
       ansible.builtin.debug:

--- a/requirements.yml
+++ b/requirements.yml
@@ -3,3 +3,4 @@ collections:
   - community.general
   - ansible.posix
   - amazon.aws
+  - kubernetes.core


### PR DESCRIPTION
- fix getting of version info when there is more than one version
- tag AWS volumes with owner info
- add make target to install ansible dependencies
- the kubernetes.core collection is required

## Summary by Sourcery

Improve version-reporting task, enhance AWS volume tagging, add Ansible dependency management, and update requirements and documentation

New Features:
- Add `ansible-deps` Makefile target for installing Ansible dependencies

Bug Fixes:
- Fix OCP versions fetching when multiple versions exist by moving temp file cleanup into a separate task

Enhancements:
- Tag AWS EBS volumes with `Owner` metadata using the `ocp_owner` variable
- Add `kubernetes.core` collection to Ansible requirements

Documentation:
- Update README to streamline installation instructions to use `make install`