### PR TITLE
Ceph perf playbook improvements

### DIFF
--- a/group_vars/all
+++ b/group_vars/all
@@ -117,6 +117,7 @@ oadp_s3_secret: "aws-s3-secret"
 oadp_backup_name: "backup1"
 
 ceph_ns: "openshift-storage"
+ceph_volume_name: "ceph-ebs"
 lso_ns: "openshift-local-storage"
 lso_sc: "lso-sc"
 

--- a/group_vars/all
+++ b/group_vars/all
@@ -51,8 +51,10 @@ ocp_arch: "amd64"
 
 aws_profile: "default"
 ebs_volume_size: 150
+ebs_volume_size_ceph: 160
 ebs_volume_type: "io2"
 ebs_device_name: "/dev/sdd"
+ebs_device_name_ceph: "/dev/sde"
 ebs_iops: 5000
 # These are unused unless doing the power90
 ebs_volume_size_two: 150
@@ -115,6 +117,8 @@ oadp_s3_secret: "aws-s3-secret"
 oadp_backup_name: "backup1"
 
 ceph_ns: "openshift-storage"
+lso_ns: "openshift-local-storage"
+lso_sc: "lso-sc"
 
 iscsi_target_iqn: iqn.2024-02.com.example
 iscsi_target_primary_ip: 10.0.100.100

--- a/playbooks/ceph.yml
+++ b/playbooks/ceph.yml
@@ -90,9 +90,22 @@
       ansible.builtin.debug:
         msg: "{{ ebs_volumes }}"
 
+    - name: Check if all items have 'volume_id'
+      assert:
+        that: item.volume_id is defined
+        fail_msg: "Missing volume_id in one of the results"
+      loop: "{{ ebs_volumes.results }}"
+      register: has_volume_id
+
     - name: Set ceph disks
       ansible.builtin.set_fact:
         ceph_disks: "{{ ebs_volumes.results | map(attribute='volume.id') | list }}"
+      when: has_volume_id is failed
+
+    - name: Set ceph disks if not created from scratch
+      ansible.builtin.set_fact:
+        ceph_disks: "{{ ebs_volumes.results | map(attribute='volume_id') | list }}"
+      when: has_volume_id is not failed
 
     - name: Template LV
       tags:

--- a/playbooks/ceph.yml
+++ b/playbooks/ceph.yml
@@ -29,7 +29,6 @@
         mode: "0644"
       loop:
         - lso-subscription.yaml
-        - lso-lv.yaml
 
     - name: Apply lso subscription and lvs
       tags:
@@ -44,7 +43,6 @@
       delay: 10
       loop:
         - lso-subscription.yaml
-        - lso-lvs.yaml
 
     - name: Find OpenShift EC2 Instances
       tags:
@@ -92,6 +90,32 @@
       ansible.builtin.debug:
         msg: "{{ ebs_volumes }}"
 
+    - name: Set ceph disks
+      ansible.builtin.set_fact:
+        ceph_disks: "{{ ebs_volumes.results | map(attribute='volume.id') | list }}"
+
+    - name: Template LV
+      tags:
+        - lso1
+      ansible.builtin.template:
+        src: ../templates/{{ item }}
+        dest: "{{ gpfsfolder }}/{{ item }}"
+        mode: "0644"
+      loop:
+        - lso-lv.yaml
+
+    - name: Apply lv
+      tags:
+        - lso1
+      ansible.builtin.shell: |
+        set -e
+        export KUBECONFIG="{{ kubeconfig }}"
+        {{ oc_bin }} apply -f "{{ gpfsfolder }}/{{ item }}"
+      register: lso_apply
+      until: lso_apply is not failed
+      loop:
+        - lso-lv.yaml
+
     - name: Template ceph files
       tags:
         - ceph1
@@ -130,10 +154,6 @@
         do
           {{ oc_bin }} label ${node} cluster.ocs.openshift.io/openshift-storage=''
         done
-
-    - name: stop
-      ansible.builtin.fail:
-        msg: "STOP HERE"
 
     - name: Apply ceph templates
       tags:

--- a/playbooks/ceph.yml
+++ b/playbooks/ceph.yml
@@ -11,6 +11,87 @@
       ansible.builtin.debug:
         msg: "Region: {{ ocp_region }} - Cluster: {{ ocp_cluster_name }}.{{ ocp_domain }} - Workers [{{ ocp_worker_count }}]: {{ ocp_worker_type }}"
 
+    - name: Get workers
+      tags:
+        - lso1
+      ansible.builtin.shell: |
+        set -e
+        export KUBECONFIG="{{ kubeconfig }}"
+        {{ oc_bin }} get nodes -l node-role.kubernetes.io/worker -o name   
+      register: workers_raw
+
+    - name: Template LSO operator 
+      tags:
+        - lso1
+      ansible.builtin.template:
+        src: ../templates/{{ item }}
+        dest: "{{ gpfsfolder }}/{{ item }}"
+        mode: "0644"
+      loop:
+        - lso-subscription.yaml
+        - lso-lv.yaml
+
+    - name: Apply lso subscription and lvs
+      tags:
+        - lso1
+      ansible.builtin.shell: |
+        set -e
+        export KUBECONFIG="{{ kubeconfig }}"
+        {{ oc_bin }} apply -f "{{ gpfsfolder }}/{{ item }}"
+      register: lso_apply
+      until: lso_apply is not failed
+      retries: 20
+      delay: 10
+      loop:
+        - lso-subscription.yaml
+        - lso-lvs.yaml
+
+    - name: Find OpenShift EC2 Instances
+      tags:
+        - ceph_disks
+      amazon.aws.ec2_instance_info:
+        profile: "{{ aws_profile }}"
+        region: "{{ ocp_region }}"
+        filters:
+          "tag:Name": "{{ ocp_cluster_name }}*worker*"
+          "instance-state-name": "running"
+      register: ec2_workers
+
+    - name: Set EC2 workers instance IDs
+      tags:
+        - ceph_disks
+      ansible.builtin.set_fact:
+        worker_ec2_ids: "{{ ec2_workers.instances | map(attribute='instance_id') | list }}"
+
+    - name: debug
+      tags:
+        - ceph_disks
+      ansible.builtin.debug:
+        msg: "{{ worker_ec2_ids }}"
+
+    - name: Create EBS io2 volume one per worker
+      tags:
+        - ceph_disks
+      amazon.aws.ec2_vol:
+        profile: "{{ aws_profile }}"
+        region: "{{ ocp_region }}"
+        availability_zone: "{{ ocp_az }}"
+        volume_size: "{{ ebs_volume_size_ceph }}"
+        volume_type: "{{ ebs_volume_type }}"
+        instance: "{{ item }}"
+        iops: "{{ ebs_iops }}"
+        device_name: "{{ ebs_device_name_ceph }}"
+        tags:
+          Name: "{{ gpfs_volume_name }}-{{ item }}"
+      register: ebs_volumes
+      loop: "{{ worker_ec2_ids }}"
+
+    - name: debug
+      tags:
+        - ceph_disks
+      ansible.builtin.debug:
+        msg: "{{ ebs_volumes }}"
+
     - name: Template ceph files
       tags:
         - ceph1
@@ -49,6 +130,10 @@
         do
           {{ oc_bin }} label ${node} cluster.ocs.openshift.io/openshift-storage=''
         done
+
+    - name: stop
+      ansible.builtin.fail:
+        msg: "STOP HERE"
 
     - name: Apply ceph templates
       tags:

--- a/playbooks/ceph.yml
+++ b/playbooks/ceph.yml
@@ -80,7 +80,7 @@
         iops: "{{ ebs_iops }}"
         device_name: "{{ ebs_device_name_ceph }}"
         tags:
-          Name: "{{ gpfs_volume_name }}-{{ item }}"
+          Name: "{{ ceph_volume_name }}-{{ item }}"
       register: ebs_volumes
       loop: "{{ worker_ec2_ids }}"
 

--- a/playbooks/destroy.yml
+++ b/playbooks/destroy.yml
@@ -105,6 +105,7 @@
         state: absent
       loop: "{{ ceph_volumes.volumes }}"
       when: ceph_volumes.volumes | default([]) | length > 0
+      failed_when: false
 
     - name: Destroy oadp s3 bucket
       tags:

--- a/playbooks/destroy.yml
+++ b/playbooks/destroy.yml
@@ -12,6 +12,23 @@
         path: "{{ ocpfolder }}/metadata.json"
       register: metadata_json_file
 
+    - name: Find OpenShift EC2 Instances
+      amazon.aws.ec2_instance_info:
+        profile: "{{ aws_profile }}"
+        region: "{{ ocp_region }}"
+        filters:
+          "tag:Name": "{{ ocp_cluster_name }}*worker*"
+          "instance-state-name": "running"
+      register: ec2_workers
+
+    - name: Set EC2 workers instance IDs
+      ansible.builtin.set_fact:
+        worker_ec2_ids: "{{ ec2_workers.instances | map(attribute='instance_id') | list }}"
+
+    - name: Debug worker instance IDs
+      ansible.builtin.debug:
+        msg: "{{ worker_ec2_ids }}"
+
     - name: Destroy ocp cluster
       tags:
         - ocp_destroy
@@ -65,6 +82,29 @@
         state: absent
       loop: "{{ volume_info_two.volumes }}"
       when: power_ninety | bool and volume_info_two.volumes | length > 0
+
+    # Delete any ceph volumes
+    - name: Get the Volume ID for ceph volumes
+      amazon.aws.ec2_vol_info:
+        profile: "{{ aws_profile }}"
+        region: "{{ ocp_region }}"
+        filters:
+          "tag:Name": "{{ ceph_volume_name }}-{{ item }}"
+      register: ceph_volumes
+      loop: "{{ worker_ec2_ids }}"
+
+    - name: Debug ceph volumes
+      ansible.builtin.debug:
+        msg: "Ceph volumes: {{ ceph_volumes }}"
+
+    - name: Delete EBS ceph volumes
+      amazon.aws.ec2_vol:
+        profile: "{{ aws_profile }}"
+        region: "{{ ocp_region }}"
+        id: "{{ item.id }}"
+        state: absent
+      loop: "{{ ceph_volumes.volumes }}"
+      when: ceph_volumes.volumes | default([]) | length > 0
 
     - name: Destroy oadp s3 bucket
       tags:

--- a/playbooks/pvc-snapshot-checksum.yml
+++ b/playbooks/pvc-snapshot-checksum.yml
@@ -38,7 +38,7 @@
 - name: Store the md5 output
   ansible.builtin.shell: |
     export KUBECONFIG="{{ kubeconfig }}"
-    oc logs checksum-data
+    {{ oc_bin }} logs checksum-data
   register: snapshot_md5
 
 - name: Put the md5 output in a dictionary

--- a/playbooks/pvc-snapshot-checksum.yml
+++ b/playbooks/pvc-snapshot-checksum.yml
@@ -1,0 +1,54 @@
+- name: Create a pod to calculate checksum for snapshot
+  kubernetes.core.k8s:
+    kubeconfig: "{{ kubeconfig }}"
+    state: present
+    definition:
+      apiVersion: v1
+      kind: Pod
+      metadata:
+        name: checksum-data
+        namespace: "{{ namespace }}"
+      spec:
+        containers:
+          - name: writer
+            image: registry.redhat.io/ubi9/ubi:latest
+            command: ["/bin/sh", "-c"]
+            args:
+              - md5sum /data/testfile
+            volumeMounts:
+              - name: data-vol
+                mountPath: /data
+        restartPolicy: Never
+        volumes:
+          - name: data-vol
+            persistentVolumeClaim:
+              claimName: "{{ cloned_pvc_name }}-{{ item }}"
+
+- name: Wait for the pod to complete md5sum
+  kubernetes.core.k8s_info:
+    kubeconfig: "{{ kubeconfig }}"
+    kind: Pod
+    namespace: "{{ namespace }}"
+    name: checksum-data
+  register: pod_status
+  until: pod_status.resources | length > 0 and pod_status.resources[0].status.phase in ['Succeeded']
+  retries: 20
+  delay: 15
+
+- name: Store the md5 output
+  ansible.builtin.shell: |
+    export KUBECONFIG="{{ kubeconfig }}"
+    oc logs checksum-data
+  register: snapshot_md5
+
+- name: Put the md5 output in a dictionary
+  ansible.builtin.set_fact:
+    md5_dict: "{{ md5_dict | combine({item: snapshot_md5.stdout}) }}"
+
+- name: Delete the pod after data fill
+  kubernetes.core.k8s:
+    kubeconfig: "{{ kubeconfig }}"
+    state: absent
+    kind: Pod
+    namespace: "{{ namespace }}"
+    name: checksum-data

--- a/playbooks/pvc-snapshot-checksum.yml
+++ b/playbooks/pvc-snapshot-checksum.yml
@@ -1,3 +1,7 @@
+- name: Checksum Iteration
+  ansible.builtin.debug:
+    msg: "Iteration {{ item }}"
+
 - name: Create a pod to calculate checksum for snapshot
   kubernetes.core.k8s:
     kubeconfig: "{{ kubeconfig }}"
@@ -38,12 +42,16 @@
 - name: Store the md5 output
   ansible.builtin.shell: |
     export KUBECONFIG="{{ kubeconfig }}"
-    {{ oc_bin }} logs checksum-data
+    {{ oc_bin }} logs -n {{ namespace }} checksum-data
   register: snapshot_md5
 
 - name: Put the md5 output in a dictionary
   ansible.builtin.set_fact:
     md5_dict: "{{ md5_dict | combine({item: snapshot_md5.stdout}) }}"
+
+- name: Print md5 output 
+  ansible.builtin.debug:
+    msg: "{{ snapshot_md5.stdout }}"
 
 - name: Delete the pod after data fill
   kubernetes.core.k8s:

--- a/playbooks/pvc-snapshot-perf.yml
+++ b/playbooks/pvc-snapshot-perf.yml
@@ -171,10 +171,10 @@
 
     - name: Print checksums
       ansible.builtin.debug:
-        msg: "Original md5 {{ original_md5 }}: {{ md5_dict | to_nice_yaml }}"
+        msg: "Original md5 {{ original_md5.stdout }}: {{ md5_dict | to_nice_yaml }}"
 
     - name: Make sure the checksums are all correct
       ansible.builtin.assert:
         that:
-          - md5_dict[item] == original_md5
+          - md5_dict[item] == original_md5.stdout
       loop: "{{ iterations }}"

--- a/playbooks/pvc-snapshot-perf.yml
+++ b/playbooks/pvc-snapshot-perf.yml
@@ -12,6 +12,7 @@
     cloned_pvc_name: cloned-pvc
     volume_size: 10Gi
     iterations: "{{ range(1, 21) | list }}"
+    md5_dict: {}
   tasks:
     - name: Delete snapshot PVC
       kubernetes.core.k8s:
@@ -85,7 +86,7 @@
                 storage: "{{ volume_size }}"
             storageClassName: "{{ storage_class }}"
 
-    - name: Create a pod to write 10G zero data to the PVC
+    - name: Create a pod to write 5Gi random data to the PVC
       kubernetes.core.k8s:
         kubeconfig: "{{ kubeconfig }}"
         state: present
@@ -93,7 +94,7 @@
           apiVersion: v1
           kind: Pod
           metadata:
-            name: fill-zero-data
+            name: fill-data
             namespace: "{{ namespace }}"
           spec:
             containers:
@@ -101,7 +102,7 @@
                 image: registry.redhat.io/ubi9/ubi:latest
                 command: ["/bin/sh", "-c"]
                 args:
-                  - dd if=/dev/zero of=/data/testfile bs=1M count=10240; sync
+                  - dd if=/dev/urandom of=/data/testfile bs=1M count=5120 &> /dev/null; sync; md5sum /data/testfile
                 volumeMounts:
                   - name: data-vol
                     mountPath: /data
@@ -111,16 +112,26 @@
                 persistentVolumeClaim:
                   claimName: "{{ original_pvc_name }}"
 
-    - name: Wait for the pod to complete writing data
+    - name: Wait for the pod to complete writing data and doing md5sum
       kubernetes.core.k8s_info:
         kubeconfig: "{{ kubeconfig }}"
         kind: Pod
         namespace: "{{ namespace }}"
-        name: fill-zero-data
+        name: fill-data
       register: pod_status
       until: pod_status.resources | length > 0 and pod_status.resources[0].status.phase in ['Succeeded']
       retries: 20
       delay: 15
+
+    - name: Store the md5 in a variable
+      ansible.builtin.shell: |
+        export KUBECONFIG="{{ kubeconfig }}"
+        oc logs fill-data
+      register: original_md5
+
+    - name: Debug original md5sum
+      ansible.builtin.debug:
+        msg: "{{ original_md5 }}"
 
     - name: Delete the pod after data fill
       kubernetes.core.k8s:
@@ -128,7 +139,7 @@
         state: absent
         kind: Pod
         namespace: "{{ namespace }}"
-        name: fill-zero-data
+        name: fill-data
 
     - name: Record start time (epoch)
       ansible.builtin.set_fact:
@@ -153,3 +164,11 @@
     - name: Record entry in csv file
       ansible.builtin.shell: |
         echo "{{ storage_class }};{{ snapshot_class }};{{ elapsed_time }}" >> "{{ output_csv }}"
+
+    - name: Calculate the checksums for all the snapshots
+      ansible.builtin.include_tasks: pvc-snapshot-checksum.yml
+      loop: "{{ iterations }}"
+
+    - name: Print checksums
+      ansible.builtin.debug:
+        msg: "Original md5 {{ original_md5 }}: {{ md5_dict }}"

--- a/playbooks/pvc-snapshot-perf.yml
+++ b/playbooks/pvc-snapshot-perf.yml
@@ -183,5 +183,5 @@
       loop: "{{ iterations }}"
       loop_control:
         loop_var: item
-        label: "{{ md5_dict[item] }}"
+        label: "{{ md5_dict[item] | default('N/A') }}"
       when: do_checksums | bool

--- a/playbooks/pvc-snapshot-perf.yml
+++ b/playbooks/pvc-snapshot-perf.yml
@@ -13,6 +13,7 @@
     volume_size: 10Gi
     iterations: "{{ range(1, 21) | list }}"
     md5_dict: {}
+    do_checksums: true
   tasks:
     - name: Delete snapshot PVC
       kubernetes.core.k8s:
@@ -168,10 +169,12 @@
     - name: Calculate the checksums for all the snapshots
       ansible.builtin.include_tasks: pvc-snapshot-checksum.yml
       loop: "{{ iterations }}"
+      when: do_checksums | bool
 
     - name: Print checksums
       ansible.builtin.debug:
         msg: "Original md5 {{ original_md5.stdout }}: {{ md5_dict | to_nice_yaml }}"
+      when: do_checksums | bool
 
     - name: Make sure the checksums are all correct
       ansible.builtin.assert:
@@ -181,3 +184,4 @@
       loop_control:
         loop_var: item
         label: "{{ md5_dict[item] }}"
+      when: do_checksums | bool

--- a/playbooks/pvc-snapshot-perf.yml
+++ b/playbooks/pvc-snapshot-perf.yml
@@ -102,7 +102,7 @@
                 image: registry.redhat.io/ubi9/ubi:latest
                 command: ["/bin/sh", "-c"]
                 args:
-                  - dd if=/dev/urandom of=/data/testfile bs=1M count=5120 &> /dev/null; sync; md5sum /data/testfile
+                  - dd if=/dev/urandom of=/data/testfile bs=1M count=5120 &> /dev/null; md5sum /data/testfile
                 volumeMounts:
                   - name: data-vol
                     mountPath: /data

--- a/playbooks/pvc-snapshot-perf.yml
+++ b/playbooks/pvc-snapshot-perf.yml
@@ -126,7 +126,7 @@
     - name: Store the md5 in a variable
       ansible.builtin.shell: |
         export KUBECONFIG="{{ kubeconfig }}"
-        oc logs fill-data
+        {{ oc_bin }} logs fill-data
       register: original_md5
 
     - name: Debug original md5sum

--- a/playbooks/pvc-snapshot-perf.yml
+++ b/playbooks/pvc-snapshot-perf.yml
@@ -172,3 +172,9 @@
     - name: Print checksums
       ansible.builtin.debug:
         msg: "Original md5 {{ original_md5 }}: {{ md5_dict }}"
+
+    - name: Make sure the checksums are all correct
+      ansible.builtin.assert:
+        that:
+          - md5_dict[item] == original_md5
+      loop: "{{ iterations }}"

--- a/playbooks/pvc-snapshot-perf.yml
+++ b/playbooks/pvc-snapshot-perf.yml
@@ -126,7 +126,7 @@
     - name: Store the md5 in a variable
       ansible.builtin.shell: |
         export KUBECONFIG="{{ kubeconfig }}"
-        {{ oc_bin }} logs fill-data
+        {{ oc_bin }} logs -n {{ namespace }} fill-data
       register: original_md5
 
     - name: Debug original md5sum

--- a/playbooks/pvc-snapshot-perf.yml
+++ b/playbooks/pvc-snapshot-perf.yml
@@ -171,7 +171,7 @@
 
     - name: Print checksums
       ansible.builtin.debug:
-        msg: "Original md5 {{ original_md5 }}: {{ md5_dict }}"
+        msg: "Original md5 {{ original_md5 }}: {{ md5_dict | to_nice_yaml }}"
 
     - name: Make sure the checksums are all correct
       ansible.builtin.assert:

--- a/playbooks/pvc-snapshot-perf.yml
+++ b/playbooks/pvc-snapshot-perf.yml
@@ -178,3 +178,6 @@
         that:
           - md5_dict[item] == original_md5.stdout
       loop: "{{ iterations }}"
+      loop_control:
+        loop_var: item
+        label: "{{ md5_dict[item] }}"

--- a/templates/ceph-storagecluster.yaml
+++ b/templates/ceph-storagecluster.yaml
@@ -39,13 +39,12 @@ spec:
     dataPVCTemplate:
       metadata: {}
       spec:
-        storageClassName: gp3-csi
+        storageClassName: "{{ lso_sc }}"
         accessModes:
         - ReadWriteOnce
         volumeMode: Block
         resources:
           requests:
-            storage: 2Ti
+            storage: 120Gi
       status: {}
     portable: true
-

--- a/templates/ceph-storagecluster.yaml
+++ b/templates/ceph-storagecluster.yaml
@@ -25,6 +25,15 @@ spec:
       requests:
         cpu: '1'
         memory: 4Gi
+  monPVCTemplate:
+    spec:
+      accessModes:
+      - ReadWriteOnce
+      resources:
+        requests:
+          storage: 30Gi
+      storageClassName: gp2-csi
+      volumeMode: Filesystem
   storageDeviceSets:
   - name: ocs-deviceset
     config: {}

--- a/templates/lso-lv.yaml
+++ b/templates/lso-lv.yaml
@@ -1,0 +1,20 @@
+apiVersion: local.storage.openshift.io/v1
+kind: LocalVolume
+metadata:
+  name: local-block
+  namespace: "{{ lso_ns }}"
+spec:
+  nodeSelector:
+    nodeSelectorTerms:
+    - matchExpressions:
+        - key: cluster.ocs.openshift.io/openshift-storage
+          operator: In
+          values:
+          - ""
+  storageClassDevices:
+    - storageClassName: "{{ lso_sc }}"
+      volumeMode: Block
+      devicePaths:
+{% for disk in ceph_disks %}
+        - {{ disk }}
+{%- endfor %}

--- a/templates/lso-lv.yaml
+++ b/templates/lso-lv.yaml
@@ -16,5 +16,5 @@ spec:
       volumeMode: Block
       devicePaths:
 {% for disk in ceph_disks %}
-        - {{ disk }}
-{%- endfor %}
+        - /dev/disk/by-id/nvme-Amazon_Elastic_Block_Store_{{ disk.replace("-", "") }}
+{% endfor -%}

--- a/templates/lso-subscription.yaml
+++ b/templates/lso-subscription.yaml
@@ -1,0 +1,28 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: "{{ lso_ns }}"
+spec:
+---
+apiVersion: operators.coreos.com/v1alpha1
+kind: Subscription
+metadata:
+  name: local-storage-operator
+  namespace: "{{ lso_ns }}"
+spec:
+  channel: stable
+  installPlanApproval: Automatic
+  name: local-storage-operator
+  source: redhat-operators
+  sourceNamespace: openshift-marketplace
+---
+apiVersion: operators.coreos.com/v1
+kind: OperatorGroup
+metadata:
+  name: openshift-local-storage
+  namespace: "{{ lso_ns }}"
+spec:
+  targetNamespaces:
+    - "{{ lso_ns }}"
+  upgradeStrategy: Default


### PR DESCRIPTION
- **More lso work**
- **More ceph with lso work**
- **Use dev for disk correctly**
- **Use ad hoc monpvctemplate**
- **Do 5G but random and calculate checksums too**
- **Use proper oc bin**
- **Couple of fixes**
- **Add check that md5sums are all matching**
- **Drop the sync call**
- **Pretty print the md5 dict**
- **Fix assert**
- **Add some destroy steps and assert md5 checksums**
- **Allow to disable checksums**
- **Work when checksums are disabled**
- **Do not fail on destroy**
