### PR TITLE
Tidy up variable name

### DIFF
--- a/group_vars/all
+++ b/group_vars/all
@@ -100,7 +100,7 @@ ibmentitlementkeyfile: "{{ '~/.ibm-entitlement-key' | expanduser }}"
 ibmentitlementkey: "{{ lookup('file', ibmentitlementkeyfile) }}"
 kubeadmin_pass: "{{ lookup('file', '~/.kubeadminpass',errors='ignore' | expanduser) }}"
 ssh_pubkey: "{{ lookup('file', '~/.ssh/id_rsa.pub' | expanduser) }}"
-power_ninety: false
+baremetal_env: false
 vmpass: "{{ lookup('file', '~/.vmpass' | expanduser) }}"
 dbperf_tar: "https://acksyn.org/stuff/hammerdb-tpcc-wrapper-scripts-kit.tar"
 

--- a/playbooks/destroy.yml
+++ b/playbooks/destroy.yml
@@ -68,7 +68,7 @@
         filters:
           "tag:Name": "{{ gpfs_volume_name_two }}"
       register: volume_info_two
-      when: power_ninety | bool
+      when: baremetal_env | bool
 
     - name: Debug volume (2)
       ansible.builtin.debug:
@@ -81,7 +81,7 @@
         id: "{{ item.id }}"
         state: absent
       loop: "{{ volume_info_two.volumes }}"
-      when: power_ninety | bool and volume_info_two.volumes | length > 0
+      when: baremetal_env | bool and volume_info_two.volumes | length > 0
 
     # Delete any ceph volumes
     - name: Get the Volume ID for ceph volumes

--- a/playbooks/gpfs-setup.yml
+++ b/playbooks/gpfs-setup.yml
@@ -287,4 +287,4 @@
       {{ oc_bin }} apply -f "{{ gpfsfolder }}/{{ item }}"
     loop:
       - storageclass2.yaml
-  when: power_ninety | bool
+  when: baremetal_env | bool

--- a/playbooks/install.yml
+++ b/playbooks/install.yml
@@ -298,7 +298,7 @@
           Name: "{{ gpfs_volume_name_two }}"
           Owner: "{{ ocp_owner }}"
       register: ebs_volume_two
-      when: power_ninety | bool
+      when: baremetal_env | bool
 
     - name: Attach EBS volume to workers (2)
       tags:
@@ -310,7 +310,7 @@
         id: "{{ ebs_volume_two.volume_id }}"
         device_name: "{{ ebs_device_name_two }}"
       loop: "{{ worker_ec2_ids }}"
-      when: ebs_volume_two.volume_id is defined and power_ninety | bool
+      when: ebs_volume_two.volume_id is defined and baremetal_env | bool
 
     # Installs GPFS with the openshift-storage-scale operator
     - name: Install gpfs bits

--- a/vars/baremetal.yaml
+++ b/vars/baremetal.yaml
@@ -1,4 +1,4 @@
-power_ninety: true
+baremetal_env: true
 ebs_volume_size: 300
 ocp_cluster_name: gpfs-demo
 ocp_worker_type: c5n.metal


### PR DESCRIPTION
## Summary by Sourcery

Rename the deployment environment flag from ‘power_ninety’ to ‘baremetal_env’ and update all playbooks and variable definitions to use the new variable

Enhancements:
- Replace ‘power_ninety’ conditionals with ‘baremetal_env’ in destroy.yml, install.yml, and gpfs-setup.yml
- Update baremetal.yaml to define and enable the new ‘baremetal_env’ variable