### PR TITLE
Add bypassDiscovery: false

### DIFF
--- a/templates/cluster.yaml
+++ b/templates/cluster.yaml
@@ -7,6 +7,7 @@ spec:
     nodeSelector:
       scale.spectrum.ibm.com/daemon-selector: ""
   daemon:
+    bypassDiscovery: false
     nsdDevicesConfig:
       localDevicePaths:
       - devicePath: /dev/disk/by-id/*


### PR DESCRIPTION
See OCPNAS-105 for the full context. But basically since by default
bypassdiscovery is true, it means that you can *only* use the devices
listed in the localDevicePath array. Since the UI uses /dev/dm-0 we
set it to false, so we can use both /dev/dm-0 and /dev/disk/by-id/
