### PR TITLE
fix: Update kubeadmin password condition in install playbook

### DIFF
--- a/playbooks/install.yml
+++ b/playbooks/install.yml
@@ -106,7 +106,7 @@
     - name: Set kubeadmin password fact
       tags:
         - 1_ocp_install
-      when: kubeadmin_pass | length > 0
+      when: kubeadmin_pass is defined and kubeadmin_pass | length > 0
       block:
         - name: Encrypt kubeadmin password
           ansible.builtin.shell: |


### PR DESCRIPTION
- Changed the condition for setting the kubeadmin password fact to check if `kubeadmin_pass` is defined before checking its length. This ensures that the playbook behaves correctly when the variable is not set.

This change improves the robustness of the installation process.